### PR TITLE
Reverted a commit that broke the xPL listening socket on some platforms

### DIFF
--- a/lib/xPL_Items.pm
+++ b/lib/xPL_Items.pm
@@ -107,10 +107,15 @@ sub startup {
         $xpl_send = new Socket_Item( undef, undef, 'xpl_send' );
 
         # Find and use the first open port
-        # The socket code will select a free local port if given 0
         my $port_listen;
-        &open_port( 0, 'listen', 'xpl_listen', 1, 1 );
-        $port_listen = $::Socket_Ports{'xpl_listen'}{port};
+	for my $p (49352 .. 65535) {
+	    $port_listen = $p;
+	    last if &open_port( $port_listen, 'listen', 'xpl_listen', 1, 1);
+	}
+	# The socket code will select a free local port if given 0
+	# not working on ubuntu 12.04
+        #&open_port( 0, 'listen', 'xpl_listen', 1, 1 );
+        #$port_listen = $::Socket_Ports{'xpl_listen'}{port};
         $xpl_listen = new Socket_Item( undef, undef, 'xpl_listen' );
 
         # initialize the hub (listen) port


### PR DESCRIPTION
In a previous commit, a piece of code was introduced that should
take care of selecting a free port automatically by passing port
0 to the open_port function.

Some people reported problems with that code change (issue #3), especially on ubuntu
so I reverted that change (and only that one, the other changes were not
touched).

I verified that the code change did not work on Ubuntu 12.04 and that this commit
does work fine on the same platform.
