### PR TITLE
Fix iphone auth error

### DIFF
--- a/web/bin/get_auth.pl
+++ b/web/bin/get_auth.pl
@@ -3,4 +3,4 @@
 
 # Authority: anyone
 
-return "$Authorized";
+return  (($Authorized)?"$Authorized":'none');


### PR DESCRIPTION
This change fixes the errors visible in the MH log during the user authentication in the iPhone web UI.
