### PR TITLE
Update android_server with new features.

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -3846,9 +3846,10 @@ sub play {
 	# Support for audrey, android, and other web based clients which 
 	# played wav files are provided for.
 	if ($parms{web_file} eq "web_file") {
-	    $parms{web_file} = "playToWeb" . $Web_Play_Index . ".wav";
+	    my $wavFile = "playToWeb" . $Web_Play_Index . ".wav";
+	    $parms{web_file} = "web/" . $wavFile;
 	    print_log("play: $parms{web_file}");
-	    my $toFile = $::config_parms{html_dir} . "/$parms{web_file}";
+	    my $toFile = $::config_parms{html_alias_web} . "/" . $wavFile;
 	    copy $file, $toFile;
 	    if (defined $parms{web_hook}) {
 		foreach my $web_hook (@{$parms{web_hook}}) {

--- a/lib/Android_Item.pm
+++ b/lib/Android_Item.pm
@@ -1,0 +1,160 @@
+=begin comment
+
+Android_Item.pm
+
+This module allows MisterHouse to capture and send speech and played
+wav files to an Android unit.
+
+- mh.private.ini requirements
+
+Add "server_android_port" to your ini file.  The default port is 4444.
+The port number assigned to server_android_port must match the port
+configured in the android client.  The ports must match in order for
+the android device to receive speech events and notifications.
+
+server_android_port=4444
+
+By default, ALL speak and play events will be pushed to ALL android's
+regardless of the value in the speak/play "rooms" parameter.  If you
+want the android's to honor the rooms parameter, then you must define
+the android_use_rooms parameter in my.private.ini.  Each android declares
+a room name when the android registers with the server.
+
+android_use_rooms=1
+
+=cut
+
+use strict;
+
+package Android_Item;
+
+@Android_Item::ISA = ('Generic_Item');
+
+use HTML::Entities;    # So we can encode characters like <>& etc
+
+# Constructor
+sub new {
+    my ($class) = @_;
+    my $self = { };
+    bless $self, $class;
+
+    #Tell MH to call our routine each time something is spoken
+    #&::Speak_parms_add_hook(\&Andoid_Server::pre_speak_to_android, $self);
+    #&::Play_parms_add_hook(\&Andoid_Server::pre_play_to_android, $self);
+    &::MainLoop_pre_add_hook(\&Android_Item::state_machine, 'persistent', $self);
+
+    $self->{toggle_item} = new Generic_Item( );
+    $self->{toggle_item}->set_states('off','on');
+
+    $self->{spinner_item} = new Generic_Item( );
+    $self->{spinner_item}->set_states('one', 'two', 'three');
+
+    return $self;
+}
+
+sub state_machine {
+    my ($self) = @_;
+}
+
+sub speech_log {
+    my ($self) = @_;
+    my @last_spoken = &main::speak_log_last($main::config_parms{max_log_entries});
+    return @last_spoken;
+}
+
+sub print_log {
+    my ($self) = @_;
+    my @last_printed = &main::print_log_last($main::config_parms{max_log_entries});
+    return @last_printed;
+}
+
+sub android_xml {
+    my ($self, $depth, $fields, $num_tags, $attributes) = @_;
+    my @f = qw( speech_log print_log toggle_item spinner_item);
+
+    # Avoid filter due to no state
+    $attributes->{noFilterState} = "true";
+
+    my $xml_objects = $self->SUPER::android_xml($depth, $fields, $num_tags + scalar(@f), $attributes);
+    my $prefix = '  ' x $depth;
+
+    foreach my $f ( @f ) {
+        next unless $fields->{all} or $fields->{$f};
+
+        my $method = $f;
+	my $value;
+        if ($self->can($method)
+            or ( ( $method = 'get_' . $method )
+                and $self->can($method) )
+          ) {
+            if ( $f eq 'speech_log' ) {
+                my @a = $self->$method;
+                $value = \@a;
+            } elsif ( $f eq 'print_log' ) {
+                my @a = $self->$method;
+                $value = \@a;
+	    } else {
+		$value = $self->$method;
+		$value = encode_entities( $value, "\200-\377&<>" );
+	    }
+	} elsif (exists $self->{$f}) {
+	    $value = $self->{$f};
+	    if ( ref $value ne 'REF' ) {
+		$value = encode_entities( $value, "\200-\377&<>" );
+	    }
+	}
+
+	# Add alias to change display name on android list
+	if ($f eq 'toggle_item') {
+	    $attributes->{alias} = "Toggle Item";
+	}
+
+	if ( ref $value eq 'Generic_Item') {
+	    if ($value->can('android_xml')) {
+		my $attributes = {};
+		$attributes->{type} = ref $value;
+		$xml_objects .= $value->android_xml($depth+1, $fields, 0, $attributes);
+	    } else {
+		$xml_objects .= $prefix . "<object>\n";
+	    }
+	    $xml_objects .= $prefix . "</object>\n";
+	}
+
+        elsif ( ref $value eq 'ARRAY' ) {
+	    $attributes->{type} = "arrayList";
+	    $xml_objects .= $self->android_xml_tag ( $prefix, $f, $attributes );
+	    $prefix = '  ' x ($depth+1);
+	    foreach (@{$value}) {
+		$_ = 'undef' unless defined $_;
+		$value = $_;
+		$value = encode_entities( $value, "\200-\377&<>" );
+		$xml_objects .= $prefix . "  <value>$value</value>\n";
+	    }
+	    $prefix = '  ' x $depth;
+	    $xml_objects .= $prefix . "</$f>\n";
+        }
+
+	elsif ( ref $value eq 'HASH' ) {
+	    $attributes->{type} = "hashList";
+	    $xml_objects .= $self->android_xml_tag ( $prefix, $f, $attributes );
+	    $prefix = '  ' x ($depth+1);
+	    foreach my $key (keys %{$value}) {
+		my $val = $value->{$key};
+		$key = encode_entities( $key, "\200-\377&<>" );
+		$key =~ s/ /_/g;
+		$key =~ s/[\[\]]/_/g;
+		$val = encode_entities( $val, "\200-\377&<>" );
+		$xml_objects .= $prefix . "<$key>$val</$key>\n";
+	    }
+	    $prefix = '  ' x $depth;
+	    $xml_objects .= $prefix . "</$f>\n";
+	}
+
+	else {
+	    $xml_objects .= $self->android_xml_tag ( $prefix, $f, $attributes );
+	}
+    }
+    return $xml_objects;
+}
+
+1;

--- a/lib/Voice_Cmd.pm
+++ b/lib/Voice_Cmd.pm
@@ -712,23 +712,14 @@ sub disablevocab {
     $Vcmd_viavoice->set('');
 }
 
-# Return the number of tags which will be returned via android_xml
-sub android_query {
-    my ($self) = @_;
-    my $num_tags = $self->SUPER::android_query();
-    $num_tags += 1;
-    return $num_tags;
-}
-
 sub android_xml {
-    my ($self, $depth, %fields) = @_;
-    my $xml_objects = $self->SUPER::android_xml($depth, %fields);
+    my ($self, $depth, $fields, $num_tags, $attributes) = @_;
+    my @f = qw( text );
+    my $xml_objects = $self->SUPER::android_xml($depth, $fields, $num_tags + scalar(@f), $attributes);
     my $prefix = '  ' x $depth;
 
-    my @f = qw( text );
-
     foreach my $f ( @f ) {
-        next unless $fields{all} or $fields{$f};
+        next unless $fields->{all} or $fields->{$f};
 
         my $method = $f;
 	my $value;
@@ -743,7 +734,8 @@ sub android_xml {
             $value = encode_entities( $value, "\200-\377&<>" );
 	}
 
-	$xml_objects .= $prefix . "<$f>$value</$f>\n";
+	$value = "" unless defined $value;
+	$xml_objects .= $self->android_xml_tag ( $prefix, $f, $attributes, $value );
     }
     return $xml_objects;
 }

--- a/lib/Voice_Text.pm
+++ b/lib/Voice_Text.pm
@@ -155,9 +155,10 @@ sub speak_text {
     # synthesized text to voice is provided for.  Make a recursive call
     # to create the static file pushed to web devices.
     if ($parms{web_file} eq "web_file") {
-	$parms{web_file} = "speakToWeb" . $web_index . ".wav";
-	my $to_file = $parms{to_file}; 
-	$parms{to_file} = $::config_parms{html_dir} . "/" . $parms{web_file};
+	my $wavFile = "speakToWeb" . $web_index . ".wav";
+	$parms{web_file} = "web/" . $wavFile;
+	my $to_file = $parms{to_file};
+	$parms{to_file} = $::config_parms{html_alias_web} . "/" . $wavFile;
 	$web_index++;
 	$web_index = $web_index % 10;
         &speak_text(%parms);

--- a/web/lib/android.xsl
+++ b/web/lib/android.xsl
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:template match="/misterhouse">
+    <html>
+
+      <head>
+        <link rel="stylesheet" href="/lib/default.css" type="text/css" />
+      </head>
+
+      <body>
+        <xsl:for-each select="objects">
+          <xsl:call-template name="object"/>
+        </xsl:for-each>
+        <xsl:for-each select="//vars">
+          <ul>
+            <xsl:call-template name="var"/>
+          </ul>
+        </xsl:for-each>
+        <ul>
+          <xsl:for-each select="categories/category|groups/group|types/type">
+            <li>
+              <xsl:call-template name="link"/>
+              <xsl:for-each select="objects">
+                <xsl:call-template name="object"/>
+              </xsl:for-each>
+            </li>
+          </xsl:for-each>
+        </ul>
+      </body>
+
+    </html>
+  </xsl:template>
+
+  <xsl:template name="object">
+    <ul>
+      <xsl:for-each select="object">
+        <li>
+          <xsl:call-template name="link"/>
+          <ul>
+            <xsl:for-each select="./*[position() > 1]">
+              <li>
+                <xsl:value-of select="local-name()"/>
+                <xsl:choose>
+                  <xsl:when test="value">
+                    <ul>
+                      <xsl:for-each select="value">
+                        <li>
+                          <xsl:value-of select="."/>
+                        </li>
+                      </xsl:for-each>
+                    </ul>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:text>=</xsl:text>
+                    <xsl:value-of select="."/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </li>
+            </xsl:for-each>
+          </ul>
+        </li>
+      </xsl:for-each>
+    </ul>
+  </xsl:template>
+
+  <xsl:template name="var">
+    <xsl:for-each select="var">
+      <li>
+        <xsl:call-template name="link"/>
+        <xsl:if test="value">
+          <xsl:text>=</xsl:text>
+          <xsl:value-of select="value"/>
+        </xsl:if>
+      </li>
+      <xsl:if test="var">
+        <ul>
+          <xsl:call-template name="var"/>
+        </ul>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="link">
+    <xsl:element name="a">
+      <xsl:attribute name="href">
+        <xsl:text>/sub?android_xml(</xsl:text>
+        <xsl:value-of select="local-name(..)"/>
+        <xsl:text>=</xsl:text>
+        <xsl:variable name="apos">'</xsl:variable>
+        <xsl:variable name="bsapos">\'</xsl:variable>
+        <xsl:call-template name="replace-string">
+          <xsl:with-param name="text">
+            <xsl:call-template name="replace-string">
+              <xsl:with-param name="text">
+                <xsl:call-template name="replace-string">
+                  <xsl:with-param name="text" select="name"/>
+                  <xsl:with-param name="replace" select="$apos"/>
+                  <xsl:with-param name="with" select="$bsapos"/>
+                </xsl:call-template>
+              </xsl:with-param>
+              <xsl:with-param name="replace" select="'%'"/>
+              <xsl:with-param name="with" select="'%25'"/>
+            </xsl:call-template>
+          </xsl:with-param>
+          <xsl:with-param name="replace" select="'&amp;'"/>
+          <xsl:with-param name="with" select="'%26'"/>
+        </xsl:call-template>
+        <xsl:text>)</xsl:text>
+      </xsl:attribute>
+      <xsl:value-of select="name"/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template name="replace-string">
+    <xsl:param name="text"/>
+    <xsl:param name="replace"/>
+    <xsl:param name="with"/>
+    <xsl:choose>
+      <xsl:when test="contains($text,$replace)">
+        <xsl:value-of select="substring-before($text,$replace)"/>
+        <xsl:value-of select="$with"/>
+        <xsl:call-template name="replace-string">
+          <xsl:with-param name="text" select="substring-after($text,$replace)"/>
+          <xsl:with-param name="replace" select="$replace"/>
+          <xsl:with-param name="with" select="$with"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$text"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- Add the Android_Item.pm module which is used for android testing and provides
  examples of how to use android display features from MH Generic_Item based
  objects.
- Added web/lib/android.xls to allow http://host/sub?android_xml to be
  displayed as a proper xml page.
- Update mh/bin and Voice_Text to move speak and play wav files from the
  main web directory in the source code tree to the html_alias_web diretory
  which is typically in the data directory.
- Update Generic_Item to remove the android_query method to determine how
  many "tags" are in play.  Enhance the android_xml methods to allow better
  support for attributes which provide additional mechanisms for android
  display features.
- Update android_server.pl to fix various issues.  Use JSON for communication
  in both directions on the service channel.  Correct a problem with supporting
  multiple SSH tunnelled connections to multiple android devices.  The service
  channel now passes "version" identifiers between host and android such that
  each side understands the version of software on the other side of the channel.
  We continue to provide backwards compatibility to earlier revisions through
  this transition.
