### PR TITLE
Insteon fix to correctly sync links when off_fast is used

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -53,7 +53,7 @@ sub derive_link_state
 	my ($p_state) = @_;
 
 	my $link_state = 'on';
-	if ($p_state eq 'off')
+	if ($p_state eq 'off' or $p_state eq 'off_fast')
 	{
 		$link_state = 'off';
 	}


### PR DESCRIPTION
Insteon::BaseInsteon::sub derive_link_state() defaulted to "on" as the link state if it didn't
understand the link state.  "Off_fast" is a valid link state and should be recognized as
equivalent to off instead of defaulting to on.
