### PR TITLE
Initial code added to Voice::Text

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -2972,9 +2972,9 @@ sub exit_pgm {
     }
 
 
-    if ($main::Info{OS_name}=~ /darwin/i) {  # Should go into Voice::Text?
-      Dispose_Speech_Channel();
-    }
+    #if ($main::Info{OS_name}=~ /darwin/i) {  # Should go into Voice::Text?
+    #  Dispose_Speech_Channel();
+    #}
     &Voice_Cmd::remove_voice_cmds if $config_parms{voice_cmd};
     &Exit_hooks();              # Allow user code exits
     &run_kill_processes;        # From handy_utilities ... kills anybody that isn't done yet
@@ -6067,11 +6067,11 @@ sub speak {
 #   print "Warning, speak control not recognized: key=$key value=$value\n"
 #            unless grep $key eq $_, @speak_parms;
 
-    if ($main::Info{OS_name}=~ /darwin/i) {   # Should go into Voice::Text? (YES!! It should.)
-      print "Trying to speak $phrase\n";
-      speak_mac ($phrase);
-      return;
-    }
+    #if ($main::Info{OS_name}=~ /darwin/i) {   # Should go into Voice::Text? (YES!! It should.)
+    #  print "Trying to speak $phrase\n";
+    #  speak_mac ($phrase);
+    #  return;
+    #}
 
     $parms{mode}  = '' unless $parms{mode};
     $parms{rooms} = $parms{room}    if $parms{room}; # Allow for room or rooms

--- a/lib/Voice_Text.pm
+++ b/lib/Voice_Text.pm
@@ -18,15 +18,11 @@ sub init {
 
     $web_index = 0;
 
-# The darwin hook is currently done in the main bin/mh code
-#    if ($main::Info{OS_name}=~ /darwin/i) {
-#        &main::my_use("Mac::Sound");
-#		&main::my_use("Mac::Speech");
-#        my $voice = $main::config_parms{speak_voice};
-#        $voice = 'Albert' unless $voice;
-#        my $Mac_voice = $Mac::Speech::Voice{$voice};
-#        $VTxt_mac = NewSpeechChannel($Mac_voice); # Need a default voice here?
-#    }
+	# OS X
+    if ($main::Info{OS_name}=~ /darwin/i) {
+        my $voice = $main::config_parms{speak_voice};
+        $voice = 'Albert' unless $voice;
+    }
 
     if (($main::config_parms{voice_text} =~ /festival/i or $engine and $engine eq 'festival') and
         $main::config_parms{festival_host}) {
@@ -207,7 +203,7 @@ sub speak_text {
 #       $speak_pgm = "$path/bin/TTSDesktopPlayer      -data $path/data -xml";
     }
     elsif ($main::Info{OS_name}=~ /darwin/i) {
-        $speak_pgm = 'MacSpeech' unless $speak_pgm;
+        $speak_pgm = 'say' unless $speak_pgm;
 #       $speak_pgm = 'osascript' unless $speak_pgm;
     }
     elsif ($speak_engine =~ /viavoice/i or $speak_engine =~ /vv_tts/i) {
@@ -521,11 +517,12 @@ sub speak_text {
 
                 $speak_pgm .= " > /dev/null" unless $main::Debug{voice} and $main::Debug{voice} > 1;
             }
-            elsif ($speak_pgm eq 'MacSpeech') {
-                my $volume_reset = GetDefaultOutputVolume();
-                SetDefaultOutputVolume(2**$parms{volume}) if $parms{volume};
-                SpeakText($VTxt_mac, $parms{text});
-                SetDefaultOutputVolume(2**$volume_reset)  if $parms{volume};
+            elsif ($speak_pgm eq 'say') {
+            	system "say $parms{text}";
+                #my $volume_reset = GetDefaultOutputVolume();
+                #SetDefaultOutputVolume(2**$parms{volume}) if $parms{volume};
+                #SpeakText($VTxt_mac, $parms{text});
+                #SetDefaultOutputVolume(2**$volume_reset)  if $parms{volume};
 #               sleep 1 while SpeechBusy();
             }
             elsif ($speak_pgm eq 'osascript') {


### PR DESCRIPTION
This is an initial attempt to get TTS working on OS X with the default TTS tools included in the OS.
Up to now TTS on OSX required separate code to be enabled under code/common. The idea is to integrate
TTS on OS X into MH just like the unix/windows interface is built.
