### PR TITLE
get_first_empty_address should return 0 if no addr

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -1298,7 +1298,7 @@ sub get_first_empty_address
 				$low_address = $new_address if $new_address < $low_address;
 			}
 		}
-		$first_address = sprintf('%04X', $low_address - 8);
+		$first_address = ($low_address > 0) ? sprintf('%04X', $low_address - 8) : 0;
 	}
 
         return $first_address;


### PR DESCRIPTION
The sub add_link expects get_first_empty_address to return 0 if no empty address is found.

This will prevent trying to add an aldb record to the FFFFFFFFFFFFFFF8 address which clearly doesn't exist.  Instead the user will now get a nice error advising them to scan the link table before trying to sync links.

It appears that something about Marc Merlin or my changes have some difference in the line endings.  Not sure why the additional lines 1222-24 1244-45 are listed as changed.
