### PR TITLE
Fix typos in AllLinkDatabase

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -796,7 +796,7 @@ sub delete_orphan_links
 					: &Insteon::get_object($deviceid,'01');
 			if (!($linked_device))
                         {
-                        	# no device is known by mh with the ADLB record's deviceid
+                        	# no device is known by mh with the ALDB record's deviceid
                         	if ($audit_mode)
                                 {
 					&::print_log("[Insteon::ALDB_i1] (AUDIT) " . $selfname . " now deleting orphaned link w/ details: "
@@ -1212,7 +1212,7 @@ sub add_duplicate_link_address
         unshift @{$$self{aldb}{duplicates}}, $address;
 
         # now, keep the list sorted!
-        @{$$self{adlb}{duplicates}} = sort(@{$$self{aldb}{duplicates}});
+        @{$$self{aldb}{duplicates}} = sort(@{$$self{aldb}{duplicates}});
 
 }
 
@@ -1262,7 +1262,7 @@ sub add_empty_address
         }
 
         # now, keep the list sorted!
-        @{$$self{adlb}{empty}} = sort(@{$$self{aldb}{empty}});
+        @{$$self{aldb}{empty}} = sort(@{$$self{aldb}{empty}});
 
 }
 


### PR DESCRIPTION
ALDB was accidentally typed ADLB in a few places.  These are likely causing some unnoticed errors, particularly with sorting.

Again, for some reason, 1222-24 and 1244-45 show as changed.  Maybe Marc and I use different line endings?? 
