### PR TITLE
Get_first_emtpy_address - ALDB entries that lack an address should be ignored

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -1295,7 +1295,7 @@ sub get_first_empty_address
 			}
                         else
                         {
-				$low_address = $new_address if $new_address < $low_address;
+				$low_address = $new_address if (($new_address < $low_address) && ($new_address != 0));
 			}
 		}
 		$first_address = ($low_address > 0) ? sprintf('%04X', $low_address - 8) : 0;


### PR DESCRIPTION
When a link is added by MH, the record is first put into the aldb hash without an address as a sort of placeholder.  Get_first_empty_address is then called to find an empty location in which to put the record.

Get_first_empty_address then loops through the aldb hash looking for the lowest used address.  In looping, it will come across the record that was just described, which lacks an address.  The subroutine then hexes the address, or lack there of, which for the placeholder results in an address of 0.  The subroutine then improperly interprets this, the 0 result, as the lowest address.

This results in bizarre situations.  In the most benign situation, the subroutine reports that it cannot find an unused address which results in an error requesting a re-scan of the device (this was happening to me a lot).  In the more dangerous situation, the subroutine may report a used address as being empty which results in that address being over written.

This patch prevents an address of 0 from being used as a low address, effectively ignoring the placeholder added above and preventing the issues described.  This is a further patch to the empty_aldb patch that I previously submitted.
