### PR TITLE
Fix issue #46 - Stop Scanning Out of Use Entries

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -440,9 +440,9 @@ sub _on_peek
                         		$message->failure_callback($$self{_failure_callback});
                                 	$self->_send_cmd($message);
 				} else {
-					$self->add_empty_address($$self{pending_aldb}{address});
+					$self->add_empty_address($$self{_mem_msb} . $$self{_mem_lsb});
 					if ($$self{_mem_activity} eq 'scan'){
-						my $newaddress = sprintf("%04X", hex($$self{pending_aldb}{address}) - 8);
+						my $newaddress = sprintf("%04X", hex($$self{_mem_msb} . $$self{_mem_lsb}) - 8);
 						$$self{pending_aldb} = undef;
 						$self->_peek($newaddress);
 					}


### PR DESCRIPTION
ALDB_Flag identifies addresses not in use, if one is found mark it as empty and skip the remaining 7 peeks.  Speeds things up on some networks, particularly if you have added and deleted a lot of links.
