### PR TITLE
Ignore Peek and Set_msb Replied Where Cmd1 is Invalid

### DIFF
--- a/lib/Insteon/BaseInterface.pm
+++ b/lib/Insteon/BaseInterface.pm
@@ -371,11 +371,20 @@ sub on_standard_insteon_received
                                         {
                                         	if (lc $self->active_message->setby->device_id eq lc $msg{source})
                                                 {
-                                                	# prevent re-processing transmit queue until after clearing occurs
-                                                        $self->transmit_in_progress(1);
-                        		       		# ask the object to process the received message and update its state
-		   					$object->_process_message($self, %msg);
-                   					$self->clear_active_message();
+                                                	if ((($self->active_message->command eq 'peek') && ($msg{cmd_code} ne '2b')) 
+                                                		|| (($self->active_message->command eq 'set_address_msb') && ($msg{cmd_code} ne '28')))
+                                                	{
+								&main::print_log("[Insteon::BaseInterface] WARN: received a message from "
+									. $object->get_object_name . " in response to a "
+									. $self->active_message->command . " command, but the command code "
+									. $msg{cmd_code} . " is incorrect. Ignorring received message.");
+                                                	} else {
+	                                                	# prevent re-processing transmit queue until after clearing occurs
+	                                                        $self->transmit_in_progress(1);
+	                        		       		# ask the object to process the received message and update its state
+			   					$object->_process_message($self, %msg);
+	                   					$self->clear_active_message();
+                                                	}
                                                 }
                                                 else
                                                 {


### PR DESCRIPTION
Fixes hollie/misterhouse#56

Responses to Peek requests should contain command code 2b as Cmd1, if we receive a message in which Cmd1 is not 2b, then it could either be corrupted or an out of sequence message.  To prevent corrupting MH link hash, ignore the message.  This will cause a resend to occur.

Similarly Set_msb responses should contain command code 28 as Cmd1.  Do the same if Cmd1 is incorrect.

This logic probably would be more appropriate in the _on_peek portion of AllLinkDatabase.pm, however, _on_standard_receive blindly clears the active message without concern for whether the messages are valid.  As such, the logic had to be placed at the lower BaseInsteon.pm level.
