### PR TITLE
Add_Link Change ALDB Health from Empty to Good

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -257,6 +257,7 @@ sub _on_poke
 				$$self{aldb}{$aldbkey}{deviceid} = lc $$self{pending_aldb}{deviceid};
 				$$self{aldb}{$aldbkey}{group} = lc $$self{pending_aldb}{group};
 				$$self{aldb}{$aldbkey}{address} = $$self{pending_aldb}{address};
+				$self->health("good");
 			}
 			# clear out mem_activity flag
 			$$self{_mem_activity} = undef;


### PR DESCRIPTION
If we can add a link, the ALDB health cannot be corrupt.  If aldb health is not updated to good from empty, log links will never print the link table.

Fixes hollie/misterhouse#59
