### PR TITLE
Fix Error in Delete Orphans which Caused Process to Occur Out of Sequence

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -2076,7 +2076,6 @@ sub delete_link
                 if ($link_parms{callback})
                 {
 			$$self{_success_callback} = $link_parms{callback};
-                        $message->callback($link_parms{callback});
                 }
                 $message->interface_data($cmd);
 		$$self{device}->queue_message($message);

--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -417,15 +417,22 @@ sub _parse_data {
                                         {
                                                 # clear the active message because we're done
                 				$self->clear_active_message();
-						my $callback = $pending_message->callback(); #$$self{_mem_callback};
-						$$self{_mem_callback} = undef;
-                                                if ($callback)
+
+						my $callback;
+						if ($self->_aldb->{_success_callback}){
+							$callback = $self->_aldb->{_success_callback};
+							$self->_aldb->{_success_callback} = undef;
+						} elsif ($$self{_mem_callback})
                                                 {
+							$callback = $pending_message->callback(); #$$self{_mem_callback};
+							$$self{_mem_callback} = undef;
+                                                }
+                                                if ($callback){
 							package main;
 							eval ($callback);
 							&::print_log("[Insteon_PLM] WARN1: Error encountered during ack callback: " . $@)
 								if $@ and $main::Debug{insteon} >= 1;
-							package Insteon_PLM;
+							package Insteon_PLM;	
                                                 }
 					}
 				}
@@ -449,7 +456,7 @@ sub _parse_data {
                                                 	$self->_aldb->health("good");
                                                 }
 						if ($$self{_mem_callback})
-                                        	{
+						{
 							my $callback = $$self{_mem_callback};
 							$$self{_mem_callback} = undef;
 							package main;


### PR DESCRIPTION
Remove message callback from PLM Delete_Link and insert ALDB_Callback in Insteon_PLM.

Message callback is called as soon as the message is sent, and then it was again called on receiving the ACK.  Which resulted in at least two instances of Delete Orphans running.

Fix hollie/misterhouse#61
