### PR TITLE
Callback switches back to wrong name space

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -1506,7 +1506,7 @@ sub _process_sync_queue {
 		&::print_log("[Insteon::BaseController] error in sync links callback: " . $@)
 			if $@ and $main::Debug{insteon};
 		$$self{sync_queue_callback} = undef;
-		package Insteon::Insteon_link;
+		package Insteon::BaseController;
 	}
 }
 


### PR DESCRIPTION
package Insteon::Insteon_link should be package Insteon::BaseController in Insteon::BaseController->_process_sync_queue()
