### PR TITLE
Add a message to the Log File for User Code Errors

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -2853,7 +2853,7 @@ sub eval_user_code_load {
 
         exit 1 if !$user_code_last_good;
 
-        print "\nLoading in previous user code\n";
+        &print_log("Error in user code.\nLoading in previous user code\n");
         $user_code = $user_code_last_good;
         &eval_user_code_reset;
         eval $user_code;


### PR DESCRIPTION
Simple fix for issue #43.

Add a single line print log entry if there are errors in the user code file.
