### PR TITLE
Pocketsphinx Error Message Addition

### DIFF
--- a/lib/PocketSphinx.pm
+++ b/lib/PocketSphinx.pm
@@ -263,13 +263,13 @@ sub build_lm {
   # quick_lm -s <sentence_file> [-w <word_file>] [-d discount]\n"); }
   my ($pgm_root,$data_root,$logfile) = @_;
 
-  my $binary = "$pgm_root/sphinx_lm_convert";
-  if (!-e $binary) {
-      &main::print_log ("PocketSphinx_Control:: ERROR: file: $pgm_root/sphinx_lm_convert MISSING!!");
-      &main::print_log ("PocketSphinx_Control:: Did you forget to install the Cmuclmtk?");
+  my $binary = "$pgm_root/sphinx_lm_convert";
+  if (! -e $binary) {
+      &main::print_log ("PocketSphinx Control:: ERROR: file: $binary MISSING!!");
+      &main::print_log ("PocketSphinx Control:: Did you forget to install the Cmuclmtk?");
   }
 
-+  open(LOG,">$logfile");
+  open(LOG,">$logfile");
 
   my $cmd = "$pgm_root/text2wfreq < $data_root.sent | $pgm_root/wfreq2vocab > $data_root.vocab";
   print LOG "$cmd\n";


### PR DESCRIPTION
Add a log message to identify if the required sphinx_lm_convert
program cannot be found. This typically means that the Cmuclmtk
tool kit has not been installed.
