### PR TITLE
Update for Android Support

### DIFF
--- a/lib/Door_Item.pm
+++ b/lib/Door_Item.pm
@@ -85,6 +85,7 @@ sub initialize
    $$self{'alarm_action'} = '';
    $$self{last_open} = 0;
    $$self{last_closed} = 0;
+   @{$$self{states}} = ('open','closed');
 }
 
 # If an alarm is set, the specified action is executed if the 

--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -1490,7 +1490,7 @@ sub android_xml {
 
     # Add tags name, state, and optional state_log
     my @f = qw( name );
-    if (scalar($self->get_states( )) > 0) {
+    if ( ((defined $self->{states}) && (scalar(@{$$self{states}}) > 0)) || (defined $self->state( ))) {
 	push @f, qw ( state );
     }
     if ($log_size > 0) {
@@ -1521,8 +1521,14 @@ sub android_xml {
 	}
 
 	if ($f eq "state") {
-	    my @states = $self->get_states( );
-	    my $numStates = @states;
+	    my @states = ();
+	    push (@states,@{$$self{states}}) if defined $self->{states};
+	    my $numStates = scalar(@states);
+	    my $state = $self->state( );
+	    &::print_log("android_xml: numStates: $numStates state: $state states: @states") if $::Debug{android};
+	    if (($numStates eq 0) && (defined $state) && (length($state) < 20)) {
+		push (@states, $state);
+	    }
 	    $attributes->{type} ="text";
 	    if ($numStates eq 2) {
 		$attributes->{type} = "toggle";


### PR DESCRIPTION
o Update Generic_Item.pm such that single state values can be displayed on Android.
o Update Door_Item.pm with state values open/closed such that their state values can be display on Android.
