### PR TITLE
Insteon: Don't Increase Hop Count When Messages are Received but Ignorred

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -528,33 +528,22 @@ sub _process_message
 	}
         elsif ($msg{is_nack})
         {
-#		if ($$self{awaiting_ack})
-#                {
-		# NOTE!!! NACKs are usually a sign of a burnt-out bulb!!
-#			&::print_log("[Insteon::BaseObject] WARN!! encountered a nack message for " . $self->{object_name}
-#				. " ... waiting for retry");
-#		}
-#                else
-#                {
-         if ($self->isa('Insteon::BaseLight')) {
-
-            &::print_log("[Insteon::BaseObject] WARN!! encountered a nack message ("
-               . $self->get_nack_msg_for( $msg{extra} ) 
-               .") for " 
-               . $self->{object_name}
-					. ".  It may be unplugged, have a burned out bulb, or this may be a new I2CS ".
-					"type device that must first be manually linked to the PLM using the set button.") if $main::Debug{insteon};
-         }
-         else {
-            &::print_log("[Insteon::BaseObject] WARN!! encountered a nack message ("
-               . $self->get_nack_msg_for( $msg{extra} ) 
-               .") for " 
-               . $self->{object_name}
-					. " ... skipping");
-         }
-			$self->is_acknowledged(0);
-			$self->_process_command_stack(%msg);
-#		}
+		if ($self->isa('Insteon::BaseLight')) {
+			&::print_log("[Insteon::BaseObject] WARN!! encountered a nack message ("
+			. $self->get_nack_msg_for( $msg{extra} ) .") for " . $self->{object_name}
+			. ".  It may be unplugged, have a burned out bulb, or this may be a new I2CS "
+			. "type device that must first be manually linked to the PLM using the set button.") 
+			if $main::Debug{insteon};
+		}
+		else 
+		{
+			&::print_log("[Insteon::BaseObject] WARN!! encountered a nack message ("
+			. $self->get_nack_msg_for( $msg{extra} ) .") for " . $self->{object_name}
+			. " ... skipping");
+		}
+		$self->active_message->no_hop_increase(1);
+		$self->is_acknowledged(0);
+		$self->_process_command_stack(%msg);
 	}
         elsif ($msg{command} eq 'start_manual_change')
         {

--- a/lib/Insteon/BaseInterface.pm
+++ b/lib/Insteon/BaseInterface.pm
@@ -379,6 +379,7 @@ sub on_standard_insteon_received
 									. $object->get_object_name . " in response to a "
 									. $self->active_message->command . " command, but the command code "
 									. $msg{cmd_code} . " is incorrect. Ignorring received message.");
+								$self->active_message->no_hop_increase(1);
                                                 	} else {
 	                                                	# prevent re-processing transmit queue until after clearing occurs
 	                                                        $self->transmit_in_progress(1);
@@ -436,6 +437,7 @@ sub on_standard_insteon_received
                                                 &main::print_log("[Insteon::BaseInterface] ERROR: received ACK/NACK message from "
                                                 	. $object->get_object_name . " but unable to process $msg{type} message type."
                                                         . " IGNORING received message!!");
+                                                $self->active_message->no_hop_increase(1);
                                         }
                         	}
                                 else

--- a/lib/Insteon/Message.pm
+++ b/lib/Insteon/Message.pm
@@ -86,6 +86,16 @@ sub respond
         return $$self{respond};
 }
 
+sub no_hop_increase
+{
+	my ($self, $no_hop_increase) = @_;
+        if ($no_hop_increase)
+        {
+        	$$self{no_hop_increase} = $no_hop_increase;
+        }
+        return $$self{no_hop_increase};
+}
+
 sub send
 {
         my ($self, $interface) = @_;
@@ -98,15 +108,18 @@ sub send
                         	. $self->to_string() . " after " . $self->send_attempts
                         	. " attempts.") if $main::Debug{insteon};
                         # revise default hop count to reflect retries
-                        if (ref $self->setby && $self->setby->isa('Insteon::BaseObject'))
+                        if (ref $self->setby && $self->setby->isa('Insteon::BaseObject') 
+                        	&& !defined($$self{no_hop_increase}))
                         {
                         	if ($self->setby->default_hop_count < 3)
                                 {
                                 	$self->setby->default_hop_count($self->setby->default_hop_count + 1);
-					&main::print_log("[Insteon::Message] Now adding hop count of "
-                                                . $self->setby->default_hop_count . " to hop history of "
-						. $self->setby->get_object_name);
                                 }
+                        }
+                        elsif (defined($$self{no_hop_increase}) && $main::Debug{insteon}){
+                        	&main::print_log("[Insteon::BaseMessage] Hop count not increased for "
+                        		. $self->setby->get_object_name . " because no_hop_increase flag was set.");
+                        	$$self{no_hop_increase} = undef;
                         }
                 }
 

--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -523,6 +523,7 @@ sub _parse_data {
 					# We have a problem (Usually we stepped on another X10 command)
 					&::print_log("[Insteon_PLM] ERROR: encountered $parsed_data. "
                                         	. $pending_message->to_string());
+                                        $self->active_message->no_hop_increase(1);
 					$self->retry_active_message();
 					#move it off the top of the stack and re-transmit later!
 					#TODO: We should keep track of an errored command and kill it if it fails twice.  prevent an infinite loop here
@@ -553,6 +554,7 @@ sub _parse_data {
                                                         . " Discarding received data.");
 				       		#$residue_data .= $parsed_data;
                                         }
+                                        $self->active_message->no_hop_increase(1);
                                 }
                                 else
                                 {
@@ -668,6 +670,7 @@ sub _parse_data {
 				&::print_log("[Insteon_PLM] DEBUG3: Interface extremely busy. Resending command"
 					. " after delaying for $nack_delay second") if $main::Debug{insteon} >= 3;
 				$self->_set_timeout('xmit',$nack_delay * 1000);
+				$self->active_message->no_hop_increase(1);
                                 $self->retry_active_message();
 				$process_next_command = 0;
 				$nack_count++;


### PR DESCRIPTION
Cleaned up coding formatting surrounding NACK message handling in BaseInsteon _process_message.

Removed superlous Hop Count Increased logging messages.

Added no_hop_increase flag to BaseMessage object.  When defined, this flag will prevent the hop count from increasing when a message is resent.  This flag should be set when the need to resend the message is not as a result of a failure of the device to receive the message.

no_hop_increase flag is set to the following situations:
- NACK received from a device
- Incorrect cmd1 code for peek or set_address_msb messages
- Cmd1 not a valid command messages
- PLM ACK mismatch
- PLM extremely busy

I am sure there are more instances in which the flag should be set.
