### PR TITLE
Enable DTR on the serial port when checking for new data from an MR26

### DIFF
--- a/lib/X10_MR26.pm
+++ b/lib/X10_MR26.pm
@@ -55,7 +55,11 @@ $prev_data = $prev_time = $prev_done = 0;
 
 sub check_for_data {
     my ($self) = @_;
+
+    # Sending commands to another device on the same serial port may have dropped
+    # the DTR signal, so let the MR-26 know we're ready to recieve data again
     $main::Serial_Ports{MR26}{object}->dtr_active(1);
+
     &main::check_for_generic_serial_data('MR26');
     my $data = $main::Serial_Ports{MR26}{data_record};
     $main::Serial_Ports{MR26}{data_record} = undef;


### PR DESCRIPTION
When a CM17 and MR26 share the same serial port, the DTR flag gets cleared on the serial port after the CM17 sends a command.  This patch turns DTR back on when the MR26 polls for new data so misterhouse can continue to receive X10 events after sending a command through the CM17.
