### PR TITLE
Updated MHL to run from same directory as mhl script

### DIFF
--- a/bin/mhl
+++ b/bin/mhl
@@ -7,7 +7,7 @@
 # su xyz 
 
 # Set current working directory to location of this script (bin/)
-cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$( cd "$( dirname "$0" )" && pwd )"
 
 while [ 1 = 1 ]; do 
 


### PR DESCRIPTION
Updated MHL to allow both absolute and relative paths

E.g.
Instead of running:
    cd /opt/misterhouse/bin
    ./mhl

You can now run:
    /opt/misterhouse/bin/mhl
OR from the misterhouse root directory:
    ./bin/mhl
