### PR TITLE
Using VERSION to determine the MisterHouse program version.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+unstable

--- a/bin/mh
+++ b/bin/mh
@@ -54,34 +54,18 @@ BEGIN {
     }
     chdir $Pgm_Path;            # Base everything from the mh dir.
 
-	# Are we running from within a subversion repository?
-	my $entries='../.svn/entries';
-	my $revision=undef;
-	if (-r $entries) {
-		open (ENTRIES, $entries);
-		my $line1=<ENTRIES>;
-		# $entries can be either XML (svn < 1.4) or just text (svn >= 1.4)
-		if ($line1 =~ /xml/) {
-			while (<ENTRIES>) {
-				next unless /revision="(\d+)"/;
-		    	$revision=$1;
-				last;
-			}
-		} else  {
-			# the revision number is the 11th line.  We have already read 1 line
-			for (1..10) {
-				$revision=<ENTRIES>;
-			}
-			chomp $revision;
-		}
-		close (ENTRIES);
+    # Determine the VERSION
+    my $autover;
+
+    if (-e '../VERSION') {
+        open (VERSION, '../VERSION');
+	$autover = <VERSION>;
+	chomp $autover;
+	close (VERSION);
     }
 
-	$Version = "mh 2.105";
-	if ($revision) {
-		$Version.=" R${revision}";
-	}
-	$Version .= " (compiler: $Info{Perl_compiled})" if $Info{Perl_compiled};
+    $Version = $autover || 'unknown';
+    $Version .= " (compiler: $Info{Perl_compiled})" if $Info{Perl_compiled};
 
 #   $Pgm_Path = '.';
 


### PR DESCRIPTION
I propose to use the VERSION file in the root of the MisterHouse codebase to determine what version of Misterhouse we're running.
This is opposed to the hardcoded version in bin/mh.

I've cleaned out some legacy code that tried to determine the svn version (we're no longer using that) and now bin/mh reads the VERSION file. For the master branch this file reads 'unstable' by default. When we make a new version now, we only need to update the version number in the VERSION file to have it pushed to all locations in mh that rely on or use the version number.
