### PR TITLE
Modify list_groups_by_object to allow for non-recursive listing

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -3183,12 +3183,12 @@ sub list_files_by_webname {
 }
 
 sub list_groups_by_object {
-    my ($object) = @_;
+    my ($object, $no_child_members) = @_;
     my @groups;
     for my $group_name (&list_objects_by_type('Group')) {
       my $group = &get_object_by_name($group_name);
 #     print "testing group=$group_name -> $group\n";
-      for my $object2 (list $group) {
+      for my $object2 ($group->list(undef, undef,$no_child_members)) {
     push @groups, $group if $object eq $object2;
       }
     }


### PR DESCRIPTION
list_groups_by_object identifies all of the groups that an object is a member of.  Currently, if an object is a member of a child group, the child and parent group will be returned in the list.

This change allows for only the groups which the object is a direct member of to be returned.

No code in MH currently uses this function, so altering it shouldn't have any impact.  Additionally, only an additional argument was added, so any user code relying on this function should still work properly even with only a single argument.
