### PR TITLE
Fixed #77

### DIFF
--- a/lib/xPL_Items.pm
+++ b/lib/xPL_Items.pm
@@ -1020,7 +1020,7 @@ sub tie_value_convertor {
 sub device_monitor {
     my ( $self, $monitor_info ) = @_;
     if ($monitor_info) {
-	my ($key,$value) = $monitor_info =~ /(\S+)\s*[:=]\s*(\S+)/;
+	my ($key,$value) = $monitor_info =~ /(\S+)\s*[:=]\s*(.+)/;
         if ( !( $value or $value =~ /^0/ ) ) {
             $value = ($key) ? $key : $monitor_info;
             $key = 'device';


### PR DESCRIPTION
In #10 I reverted a change in the xPL message parsing because it apparently caused the xPL processing of messages to stop working. In #10 I had the impression that the change was required to allow MisterHouse to support unsupported messages to be processed.
However, I was wrong there. I misinterpreted the xPL spec. When a message is created, it contains key/value pairs. Only the name of a key/value pair cannot contain a space. The value can. This fix enables processing of messages with spaces in the value of key/value pairs to be processed again.

I have verified that the current code supports both messages with and without spaces in the values of key/value pairs.
