### PR TITLE
Fixed AppStatus for xPL items.

### DIFF
--- a/lib/xPL_Items.pm
+++ b/lib/xPL_Items.pm
@@ -913,7 +913,6 @@ sub manage_heartbeat_timeout {
 
 sub dead_action {
     my ( $self, $p_actionDeadApp ) = @_;
-    $$self{m_app_Status} = 'dead';
     if ( defined $p_actionDeadApp ) {
         $$self{m_actionDeadApp} = $p_actionDeadApp;
     }
@@ -922,7 +921,8 @@ sub dead_action {
 
 sub _handle_dead_app {
     my ($self) = @_;
-    return eval $$self{m_actionDeadApp} if defined( $$self{m_actionDeadApp} );
+    $$self{m_appStatus} = 'dead';
+    return $$self{m_actionDeadApp}->() if defined( $$self{m_actionDeadApp} );
 }
 
 sub _handle_alive_app {


### PR DESCRIPTION
I want to be able to trigger an event when an xPL items goes down. I noticed I could use the AppStatus local variable for that. However, that variable is never set to
'dead' because of a typo in the local variable name. Also, the location where the variable was set to dead was incorrect.

At the same time I've changes the 'eval' for the dead_action to dead_action->() because otherwise the dead action was never executed on my system.

Now I can do
$dummy_device->dead_action(&handle_dummy_down);  #noloop

sub handle_dummy_down {
     print_log "Dummy is now down";
}

and it works! Yay!
