### PR TITLE
Don't rewrite xPL_Item state if no change

### DIFF
--- a/lib/xPL_Items.pm
+++ b/lib/xPL_Items.pm
@@ -524,7 +524,7 @@ sub _process_incoming_xpl_data {
 #           $o -> SUPER::set($state_value, 'xPL') if defined $state_value;
 
             $o->received( $data );
-            if ( defined $state_value and $state_value ne '' ) {
+            if ( defined $state_value and $state_value ne '' and $o->state() ne $state_value) {
                 my $set_by_name = 'xPL';
                 $set_by_name .= " [$source]";
                 $o->set_now( $state_value, $set_by_name );


### PR DESCRIPTION
When processing an xPL message. Don't re-write the state if no change.
This stops constant xPL_Item events for xPL messages which are only repetitive broadcasts.
