### PR TITLE
Fix Issue #132: Remove tracking scripts from user docs

### DIFF
--- a/docs/toc.html
+++ b/docs/toc.html
@@ -28,15 +28,5 @@
 <br><a href="items.html">Items</a>
 <br><a href="modules.html">Modules</a>
 
-
-<script language="javascript"> var u=6416; var vsbl=0; var l=''; </script> <script type="text/javascript" language="Javascript" src="http://hitslog.com/counter.js"></script> <script language="javascript"> document.write('<a href=http://hitslog.com/><img border=0 width=1 height=1 src=http://hitslog.com/hl.php?'+l+'></a>'); </script> <noscript> <a href="http://hitslog.com/"><img border=0 width=1 height=1 src="http://hitslog.com/hl.php?u=6416" alt="create web counter"></a> </noscript>
-
-<script src="http://www.google-analytics.com/urchin.js" type="text/javascript">
-</script>
-<script type="text/javascript">
-_uacct = "UA-586835-4";
-urchinTracker();
-</script>
-
 </body>
 </html>


### PR DESCRIPTION
docs/toc.html contained two tracking scripts which no one on the project recalls.  Scripts have been removed and can be added back in later if someone comes up with a patch that supports opt-in.  The way the docs directory works every local MH copy was running the scripts as was the toc.html on sourceforge.net.
