### PR TITLE
Insteon: Add Error Message if Root Object Cannot be Found

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -945,7 +945,12 @@ sub get_root {
 	}
         else
         {
-		return &Insteon::get_object($self->device_id, '01');
+		my $root_obj = &Insteon::get_object($self->device_id, '01');
+		::print_log ("[Insteon::BaseDevice] ERROR! Cannot find the root object for " 
+			. $self->get_object_name ". Please check your mht file to make sure "
+			"that device id " . $self->device_id . ":01 is defined.") 
+			if (!defined($root_obj));
+		return $root_obj;
 	}
 }
 


### PR DESCRIPTION
Provides a warning message if a root device cannot be found.  Such as when a user defines a keypadlinc button but does not define the root keypadlinc.  May also occur when there is a typo in the device id.

This should help users to catch errors such as issues #134, #135, and #136.
