### PR TITLE
Insteon::DimmableLight Fix convert_level to return FF for 100%

### DIFF
--- a/lib/Insteon/Lighting.pm
+++ b/lib/Insteon/Lighting.pm
@@ -107,6 +107,7 @@ sub convert_level
 	my ($on_level) = @_;
 	my $level = 'ff';
 	if (defined ($on_level)) {
+		$on_level =~ s/(\d+)%?/$1/;
 		if ($on_level eq '100') {
 			$level = 'ff';
 		} elsif ($on_level eq '0') {


### PR DESCRIPTION
100% was being converted to FE when it should be FF.

Fixes Issue #147
