### PR TITLE
Fix issue 158

### DIFF
--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -693,6 +693,13 @@ sub _parse_data {
 				}
 				$nack_count++;
 			}
+			#Remove the leading NACK bytes and place whatever remains into fragment for next read
+			$parsed_data =~ s/^(15)*//;
+			if ($parsed_data ne ''){
+				$$self{_data_fragment} .= $parsed_data;
+				::print_log("[Insteon_PLM] DEBUG3: Saving parsed data fragment: " 
+					. $parsed_data) if( $main::Debug{insteon} >= 3);
+			}
 		}
                 else
                 {


### PR DESCRIPTION
Fixes the problem where the read buffer was cleared whenever a NACK busy message was present.  This patch will trim the leading "15" byte(s) and if anything remains it will push it into the fragment for the next read.

Fixes #158 

This pull intentionally relies on pull request #155.  Since adjacent code was changed, pull request #155 should be merged first and then this request.  I apologize that it makes this pull request more difficult to read.  The only additional change is the last commit, so if you review those changes it will be easier to understand.
