### PR TITLE
Insteon: Set Device State on a Received AllLink Broadcast Message

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -566,10 +566,10 @@ sub _process_message
                 elsif ($msg{type} eq 'cleanup')
                 {
                 	if (lc($self->state) eq lc($p_state) and $$self{_pending_cleanup}){
-				$self->set($p_state, $self);
-                	} else {
 				::print_log("[Insteon::BaseObject] Ignoring Received Direct AllLink Cleanup Message for " 
 					. $self->{object_name} . " since AllLink Broadcast Message was Received.") if $main::Debug{insteon};
+                	} else {
+				$self->set($p_state, $self);
 			}
 			$$self{_pending_cleanup} = 0;
 		} else {


### PR DESCRIPTION
Fixes issue #153

The set routine is now called when a broadcase message is received.  The flag _pending_cleanup is also set.

When a Direct Cleanup Message is received, if the state of the device matches the pending state and the _pending_cleanup flag is set, we assume that this command was already processed.

This code is all adjacent to each other, so using a flag should not be confusing.

Much of the code was already there, but was commented out by Gregg in his first commit of the new insteon code.  This initial commit included a huge number of changes and no notes were added as to why this was disabled in the redux.
