### PR TITLE
Insteon: Fix Error in PLM Message Integrity Check Logic

### DIFF
--- a/lib/Insteon/MessageDecoder.pm
+++ b/lib/Insteon/MessageDecoder.pm
@@ -115,7 +115,7 @@ my %plmcmdlen = (
 	'0258' => [3, 3],
 	'0260' => [2, 9],
 	'0261' => [5, 6],
-	'0262' => [8, 9], # could get 9 or 23 (Standard or Extended Message received)
+	'0262' => [8, 9, 22, 23], # could get 9 or 23 (Standard or Extended Message received)
 	'0263' => [4, 5],
 	'0264' => [4, 5],
 	'0265' => [2, 3],
@@ -892,10 +892,15 @@ sub insteon_decode_cmd {
 }
 
 
-#Takes a 2 byte hex cmd, 0 for send, 1, for rec and returns expected byte length
+#$plm_cmd is 2 byte hex cmd; $send_rec is 0 for send, 1, for rec; $is_extended is 1 if extended send
+#returns expected byte length
 sub insteon_cmd_len{
-	my ($plm_cmd, $send_rec) = @_;
-	return $plmcmdlen{$plm_cmd}->[$send_rec]
+	my ($plm_cmd, $send_rec, $is_extended) = @_;
+	if ($is_extended && $plmcmdlen{uc($plm_cmd)} > 2) {
+		return $plmcmdlen{uc($plm_cmd)}->[($send_rec+2)];
+	} else {
+		return $plmcmdlen{uc($plm_cmd)}->[$send_rec];
+	}
 }
 
 

--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -308,8 +308,8 @@ sub _send_cmd {
          		$self->_set_timeout('command', $cmd_timeout); # a commmand needs to be PLM ack'd w/i 3 seconds or it gets dropped
                 }
         }
-
-	if (length($command) != (Insteon::MessageDecoder::insteon_cmd_len(substr($command,0,4), 0)*2)){
+	my $is_extended = ($message->command_type eq "insteon_ext_send") ? 1 : 0;
+	if (length($command) != (Insteon::MessageDecoder::insteon_cmd_len(substr($command,0,4), 0, $is_extended)*2)){
 		&::print_log( "[Insteon_PLM]: ERROR!! Command sent to PLM " . lc($command) 
 		. " is of an incorrect length.  Message not sent.");
 		$self->clear_active_message();


### PR DESCRIPTION
Fix bugs in which PLM commands with a letter were rejected as being too long. Notably this prevented the scanning of the PLM link table.

Also fix bug which prevented MH from sending extended length messages to the PLM.

Fixes Issues
hollie/misterhouse#170
mstovenour/misterhouse#14
