### PR TITLE
Insteon: Catch Error if Device ID in All_Link_Failure Does Not Exist

### DIFF
--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -636,10 +636,15 @@ sub _parse_data {
                         		. "$failure_device and group: $failure_group") if $main::Debug{insteon} >= 2;
                         
                         	my $failed_object = &Insteon::get_object($failure_device,'01');
-                        	my $message = new Insteon::InsteonMessage('all_link_direct_cleanup', $failed_object, 
-                        		$self->active_message->command, $failure_group);
-                        	push(@{$$failed_object{command_stack}}, $message);
-                        	$failed_object->_process_command_stack();
+                        	if (ref $failed_object){
+	                        	my $message = new Insteon::InsteonMessage('all_link_direct_cleanup', $failed_object, 
+	                        		$self->active_message->command, $failure_group);
+	                        	push(@{$$failed_object{command_stack}}, $message);
+	                        	$failed_object->_process_command_stack();
+                        	} else {
+                        		&::print_log("[Insteon_PLM] WARN: Device ID: $failure_device does not exist. You may "
+                        			. "want to run delete orphans to remove this link from your PLM");
+                        	}
 			} else {
 				&::print_log("[Insteon_PLM] DEBUG2: Received all-link cleanup failure."
                         		. " But there is no pending message.") if $main::Debug{insteon} >= 2;


### PR DESCRIPTION
Checks to make sure an object exists, if no object exists for that device_id then it sends a message to the log reminding the user to delete_orphan links.

Fixes mstovenour/misterhouse#17
