### PR TITLE
Insteon: Catch Cleanup Messages Sent in the Same Pass as AllLink Message...

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -703,7 +703,8 @@ sub _process_message
                 }
                 elsif ($msg{type} eq 'cleanup')
                 {
-                	if (lc($self->state) eq lc($p_state) and $$self{_pending_cleanup}){
+                	if (($self->state eq $p_state or $self->state_final eq $p_state)
+                		and $$self{_pending_cleanup}){
 				::print_log("[Insteon::BaseObject] Ignoring Received Direct AllLink Cleanup Message for " 
 					. $self->{object_name} . " since AllLink Broadcast Message was Received.") if $main::Debug{insteon};
                 	} else {


### PR DESCRIPTION
...s

Issue discovered by @peloy.  MH should be ignoring the cleanup message received after an AllLink message.  However, both messages were previously processed if they were received in the same pass.  This resolves that discrepancy by checking what the state of the object will be at the start of the next pass.

Partially fixes hollie/misterhouse#185
