### PR TITLE
Insteon: Move Failure_Reason into BaseObject from Message

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -660,7 +660,7 @@ sub _process_message
 		{
 			main::print_log("[Insteon::BaseObject] WARN: Now calling message failure callback: "
 				. $p_setby->active_message->failure_callback) if $main::Debug{insteon};
-			$p_setby->active_message->failure_reason('NAK');
+			$self->failure_reason('NAK');
 			package main;
 			eval $p_setby->active_message->failure_callback;
 			main::print_log("[Insteon::BaseObject] problem w/ retry callback: $@") if $@;
@@ -815,6 +815,26 @@ sub _is_valid_state
 sub get_nack_msg_for {
    my ($self,$msg) = @_;
    return $nack_messages{ $msg };
+}
+
+=item C<failure_reason>
+
+Stores the resaon for the most recent message failure [NAK | timeout].  Used to 
+process message callbacks after a message fails.  If called with no parameter 
+returns the saved failure reason.
+
+Parameters:
+	reason: failure reason
+
+Returns: failure reason
+
+=cut 
+
+sub failure_reason
+{
+        my ($self, $reason) = @_;
+        $$self{failure_reason} = $reason if $reason;
+        return $$self{failure_reason};
 }
 
 ####################################
@@ -1253,7 +1273,7 @@ Returns: nothing
 sub _get_engine_version_failure
 {
 	my ($self) = @_;
-	my $failure_reason = $self->interface->active_message->failure_reason();
+	my $failure_reason = $self->failure_reason();
 	
 	main::print_log("[Insteon::BaseDevice::_get_engine_version_failure] DEBUG4: "
 		."failure reason: $failure_reason") if $main::Debug{insteon} >= 4;

--- a/lib/Insteon/BaseInterface.pm
+++ b/lib/Insteon/BaseInterface.pm
@@ -249,20 +249,20 @@ sub process_queue
 					&main::print_log("[Insteon::BaseInterface] WARN! Unable to clear acknowledge for "
 						. ((defined($failed_message->setby)) ? $failed_message->setby->get_object_name : "undefined"));
 				}
-
+				# clear active message
+				$self->clear_active_message();
                                 # may instead want a "failure" callback separate from success callback
 				if ($failed_message->failure_callback)
                                 {
                                        	&::print_log("[Insteon::BaseInterface] WARN: Message Timeout:  Now calling callback: " .
                                                	$failed_message->failure_callback) if $main::Debug{insteon};
-					$failed_message->failure_reason('timeout');
+					$failed_message->setby->failure_reason('timeout') 
+						if (defined($failed_message->setby) and $failed_message->setby->can('failure_reason'));
 		       			package main;
 					eval $failed_message->failure_callback;
 					&::print_log("[Insteon::BaseInterface] problem w/ retry callback: $@") if $@;
 					package Insteon::BaseInterface;
 				}
-
-                		$self->clear_active_message();
                 		$self->process_queue();
                         }
 		}

--- a/lib/Insteon/Message.pm
+++ b/lib/Insteon/Message.pm
@@ -55,26 +55,6 @@ sub failure_callback
         return $$self{failure_callback};
 }
 
-=item C<failure_reason>
-
-Stores the resaon for the most recent message failure [NAK | timeout].  Used to 
-process message callbacks after a message fails.  If called with no parameter 
-returns the saved failure reason.
-
-Parameters:
-	reason: failure reason
-
-Returns: failure reason
-
-=cut 
-
-sub failure_reason
-{
-        my ($self, $reason) = @_;
-        $$self{failure_reason} = $reason if $reason;
-        return $$self{failure_reason};
-}
-
 sub send_attempts
 {
 	my ($self, $send_attempts) = @_;


### PR DESCRIPTION
The active_message must be cleared before calling the failure_callback, otherwise we get into a strange loop with sync and scan links
Once the active_message is cleared, we lose our ability to keep track of the failured message and corresponding failure_reason

To resolve this, moved failure_reason from the message object into BaseObject.
