### PR TITLE
Insteon: Fix Bug in Link Scan Callback When Nack Received

### DIFF
--- a/lib/Insteon.pm
+++ b/lib/Insteon.pm
@@ -114,13 +114,12 @@ sub _get_next_linkscan
 			$current_scan_device->_aldb->{_aldb_unchanged_callback} = '&Insteon::_get_next_linkscan('.$skip_unchanged.')';
 			$current_scan_device->_aldb->{_aldb_changed_callback} = '&Insteon::_get_next_linkscan('.$skip_unchanged.', '.$current_scan_device->get_object_name.')';
 			$current_scan_device->_aldb->query_aldb_delta("check");
-			$current_scan_device = undef;
 			$checking = 1;
 		}
 	} else {
 		$current_scan_device = $changed_device;
 	}
-	if ($current_scan_device)
+	if ($current_scan_device && ($checking == 0))
         {
           	&main::print_log("[Scan all link tables] Now scanning: "
                 	. $current_scan_device->get_object_name . " ("


### PR DESCRIPTION
Clearing $current_scan_device was resulting in an undefined object.  This would happen when a device's aldb was listed as out-of-sync.  In that scenario, query_aldb_delta would be called, but it would immediately call the aldb_changed_callback without exiting the loop.
The callback would then set the current_scan_device and call scan_link_table on that device.  At this point, a _send_msg would be queued and the loop would begin to exit. As it exited it would fall all the way back to line 117 of Insteon.pm and clear the current_scan_device.

This patch prevents that error, by not relying on the state of an otherwise global variable in the logic tree.
