### PR TITLE
Insteon: Redefine Active_Interface on Code Reload

### DIFF
--- a/lib/Insteon.pm
+++ b/lib/Insteon.pm
@@ -609,7 +609,7 @@ sub add_item
    my ($self,$p_object) = @_;
 
    push @{$$self{objects}}, $p_object;
-   if ($p_object->isa('Insteon::BaseInterface') and !($self->_active_interface)) {
+   if ($p_object->isa('Insteon::BaseInterface')) {
       $self->_active_interface($p_object);
    }
    return $p_object;


### PR DESCRIPTION
Failing to redefine the active_interface leads to potentially two divergent versions of the same object.
Removed logic which required that active_interface be undefined before it could be defined.
This may cause issues if two PLMs are used in MH, although it is not clear to me that two PLMs were ever supported by MH or that such support is even needed.

Closed hollie/misterhouse#57
