### PR TITLE
Insteon: Fix Hash Keys Error with Older Perl Versions

### DIFF
--- a/lib/Insteon/BaseInterface.pm
+++ b/lib/Insteon/BaseInterface.pm
@@ -614,7 +614,7 @@ sub _is_duplicate_received {
 	my $delay = ($message_time * $max_hops);
 
 	#Clean hash of outdated entries
-	for (keys $$self{received_commands}){
+	for (keys %{$$self{received_commands}}){
 		if ($$self{received_commands}{$_} < $curr_milli){
 			delete($$self{received_commands}{$_});
 		}


### PR DESCRIPTION
Hopefully this fixes the error found by Jim

see http://misterhouse.10964.n7.nabble.com/help-td18065.html
