### PR TITLE
Insteon: Set Cmd2 to 00 in All Link Send Commands

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -406,7 +406,10 @@ sub derive_message
 		return undef;
 	}
 
-	if ($p_extra)
+	if ($self->isa("Insteon::InterfaceController")) 
+	{
+		$message->extra('00') #All PLM Scenes are Cmd2=00;
+	} elsif ($p_extra)
 	{       $message->extra($p_extra);
 
 	} elsif ($subcommand) {


### PR DESCRIPTION
Per the spec, Cmd2 should be 00, was getting set to FF when on command was sent.
