### PR TITLE
Insteon: Change "initiate linking as controller" Group to 00

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -464,10 +464,10 @@ sub delete_orphan_links
 					}
                                         else
                                         {    # no corresponding PLM link found in items.mht
-						if ($group eq '01') {
-							#ignore manual responder link to PLM group 01 required for I2CS devices
+						if ($group eq '01' || $group eq '00') {
+							#ignore manual responder link to PLM group 01 or 00 required for I2CS devices
 							main::print_log("[Insteon::AllLinkDatabase] DEBUG2 Ignoring orphan responder link from "
-								. $selfname . " to PLM for group 01") if $main::Debug{insteon} >= 2;
+								. $selfname . " to PLM for group 01 or 00") if $main::Debug{insteon} >= 2;
 						}
 						elsif ($audit_mode)
                                                 {
@@ -2398,9 +2398,9 @@ sub delete_orphan_links
 				if (!($link))
                                 {
 					# a reference in the PLM's linktable does not match a scene member target
-					if ($group eq '01') {
-						#ignore manual controller link from PLM group 01 to device required for I2CS devices
-						main::print_log("[Insteon::ALDB_PLM] DEBUG2 Ignoring orphan PLM controller(01) link to "
+					if ($group eq '01' || $group eq '00') {
+						#ignore manual controller link from PLM group 01 or 00 to device required for I2CS devices
+						main::print_log("[Insteon::ALDB_PLM] DEBUG2 Ignoring orphan PLM controller(01 or 00) link to "
 							. $device->get_object_name() ) if $main::Debug{insteon} >= 2;
 					}
 					elsif ($audit_mode)

--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -240,7 +240,7 @@ sub initiate_linking_as_controller
 {
 	my ($self, $group) = @_;
 
-	$group = '01' unless $group;
+	$group = '00' unless $group;
 	# set up the PLM as the responder
 	my $cmd = '01'; # controller code
 	$cmd .= $group; # WARN - must be 2 digits and in hex!!


### PR DESCRIPTION
I was having issues where some sort of corruption within the PLM was causing it to send messages to the 01 group, very annoying.

HouseLinc uses 00, plus the insteon documents seem to envision that 01 is a valid group that could be used for other purposes.

Group 01 links will not be deleted by delete_orphans to prevent causing issues for other users.
