### PR TITLE
Insteon: Catch Status Requests in Unique _process_message Routines

### DIFF
--- a/lib/Insteon/Controller.pm
+++ b/lib/Insteon/Controller.pm
@@ -197,13 +197,20 @@ sub _process_message {
 	if ($root->_is_battery_time_expired){
 		#Queue an get_extended_info request
 		if ($$root{queue_timer}->active){
-			$$root{queue_timer}-restart();
+			$$root{queue_timer}->restart();
 		}
 		else {
 			$$root{queue_timer}->set(3, '$root->get_extended_info(1)');
 		}
 	}
-	if ($msg{command} eq "extended_set_get" && $msg{is_ack}){
+	my $pending_cmd = ($$self{_prior_msg}) ? $$self{_prior_msg}->command : $msg{command};
+	my $ack_setby = (ref $$self{m_status_request_pending}) ? $$self{m_status_request_pending} : $p_setby;
+	if ($msg{is_ack} && $self->_is_info_request($pending_cmd,$ack_setby,%msg)) {
+		$clear_message = 1;
+		$$self{m_status_request_pending} = 0;
+		$self->_process_command_stack(%msg);
+	}
+	elsif ($msg{command} eq "extended_set_get" && $msg{is_ack}){
 		$self->default_hop_count($msg{maxhops}-$msg{hopsleft});
 		#If this was a get request don't clear until data packet received
 		main::print_log("[Insteon::RemoteLinc] Extended Set/Get ACK Received for " . $self->get_object_name) if $main::Debug{insteon};


### PR DESCRIPTION
Controller and Security both have unique _process_message routines that catch messages unique to them.

Before processing a message, these routines need to check to see if the incoming message is in response to a status request.  Otherwise eventually the ALDB version number will match one of these unique message types, and MH gets confused.
