### PR TITLE
Insteon: Fix Path Comparison in Windows for Update_Docs.pl

### DIFF
--- a/bin/update_docs
+++ b/bin/update_docs
@@ -60,6 +60,7 @@ BEGIN {
 use strict;
 use warnings;
 use Pod::Html;
+use Cwd qw(abs_path);
 
 # Get parms from mh.ini
 require 'handy_utilities.pl';
@@ -242,7 +243,8 @@ closedir POD;
 # delete html files from docs dir if out dir is diff and pod exists
 my $docsi = ( stat($docdir) )[1];
 my $outi  = ( stat($outdir) )[1];
-if ( $docsi eq $outi ) {
+if ((($docsi == $outi) && ($outi == 0) && (abs_path($docdir) eq abs_path($outdir))) 
+    || (( $docsi eq $outi ) && ($outi != 0))) {
     print "you should set the html_alias2_docs directory to a place outside"
       . " the mh distribution\n directory.  Otherwise, everytime this script is"
       . " run, you will alter\n your distribution files.";


### PR DESCRIPTION
If inode==0 then we are probably on windows, so use abs_path to compare the two paths and see if they are the same.

I don't have windows so hopefully this works.

Fixes hollie/misterhouse#234
