### PR TITLE
Better Formatting in Web Interface Print Log

### DIFF
--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -1247,8 +1247,12 @@ sub html_print_log {
         $h_response .= "<a href=print_log>Refresh Print Log</a>\n";
         my @last_printed = &main::print_log_last($main::config_parms{max_log_entries});
         for my $text (@last_printed) {
-            $text =~ s/\n/\n<br>/g;
-            $h_response .= "<li>$text\n";
+            #This formatting is a little bizarre, but sub html_page blindly 
+            #converts all \n to \n\r apparently to be standards compliant. It 
+            #would be easier to set the white space of list-item to pre, however
+            #the additional newline characters added by html_page look ugly.
+            $text =~ s/\n/<\/pre><\/br>\n<pre>/g;
+            $h_response .= "<li><pre>$text</pre></li>\n";
         }
     }
     else {

--- a/web/list.css
+++ b/web/list.css
@@ -7,3 +7,4 @@ A:link { color: blue; }
 A:visited { color: lightblue; }
 A:active { color: brown; } 
 A:hover { color: green; }
+PRE { white-space:pre-wrap; font-family:courier, monospace; display:inline; font-size:10pt;}


### PR DESCRIPTION
Changed the web interface print log to a monospaced or fix width font and formatting.  This allows the nice formatting that relies on consistent spacing that has been visible in the text based logs, to be viewable online.  I realize that fixed width fonts are not always the prettiest, but I did the best I could.  If anyone has any suggestions for how to make it prettier, I am open to additional changes.

I had to work around one oddity.  The web code converts all \n characters to \n\r when formatting the html.  This is a blind conversion without any regard as to whether the \n character is within a <pre> tag.
