### PR TITLE
Do Not Move Tabbed 'Add' Entries in User Code to Global Declaration

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -4963,8 +4963,8 @@ sub read_user_code {
                 $record =~ /->\s*hidden/   or
                 $record =~  /^\s*set_(authority|icon|info|order|fp_location)\s/ or
                 $record =~ /->\s*set_(authority|icon|info|order|fp_location)/   or
-                $record =~ /^\s{0,3}\S+\s*->\s*add[\s\(]/ or
-                $record =~ /^\s{0,3}add\s/) {
+                $record =~ /^\ {0,3}\S+\s*->\s*add[\s\(]/ or
+                $record =~ /^\ {0,3}add\s/) {
                 $noloop_statement_flag = 1 unless $pod_flag; # Allow for multi-record statements
             }
 


### PR DESCRIPTION
Misterhouse merges all of the User Code files into a single file at runtime.  When merging the files, MisterHouse moves certain commands and declarations to the top of the merged file.  The purpose is to allow these "global records" to be defined early on, to avoid errors.  They include variable instantiaions and other routines.

In order to avoid moving lines which are meant to be part of a subroutine or logical statement, MisterHouse will only move theabove "global records" if they occur at the start of a line.  The thought being that coders practicing even the most basic level of standard formatting will indent statements inside of logical routines or subroutines.

The one exception to this rule is the add statement. This is generally used to add an item to a group, but a few other items have add functions as well, notably the Process_Item.

For some reason, MisterHouse will allow anywhere from 0-3 whitespaces to proceed the add statement while still considering it to be a "global record"

This is somewhat logical in that tabs are usually at least 4 spaces.  But it is unclear why this exception only applies to add functions, and not to the other functions as well.

Eitherway, a white space in perl is defined as [\ \t\r\n\f].  [\r\n\f] are unnecessary, since they would be interpreted as a newline.  The problem arose by including [\t].  In so doing, MisterHouse was moving add functions which were tabbed in 3 times.

By changing this to simply [\ ] the code at least does what the author originally intended it to do.  I think the odds that this change would cause an error for any currently existing user code files is small, but there is some remote possibility that it might.

Personally, I think the spacing should be removed entirely, but I am hesitant to change a function that is so fundamental to MisterHouse.
