### PR TITLE
Fix get email for non-system-wide Perl installations

### DIFF
--- a/bin/get_email
+++ b/bin/get_email
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # -*- Perl -*-
 #---------------------------------------------------------------------------
 #  File:
@@ -11,6 +11,8 @@
 #      http://misterhouse.net/mh/bin/get_email
 #  Change log:
 #    03/26/99  Created.
+#  Notes: 
+#    check required modules in lib/imap_utils.pl
 #
 #  This software is licensed under the terms of the GNU public license.
 #  Copyright 1999 Bruce Winter

--- a/lib/imap_utils.pl
+++ b/lib/imap_utils.pl
@@ -16,7 +16,8 @@ Requires the following perl modules:
   Time::Zone
 
 if the IMAP scan hangs before authenticating against the gmail account, reinstall the
-IO::Socket::SSL
+IO::Socket::SSL. On OS X you need to install openssl before attempting to install the 
+SSL-related Perl modules. The easiest way to do this is through homebrew (brew install openssl)
 
 Todo: parse unread messages
 


### PR DESCRIPTION
When a user installs a local Perl version to run MisterHouse under instead of using the system-provided Perl, then the hardcoded Perl path at the shebang in get_email causes the module search path to be incorrect. 

```
#!/usr/bin/env perl
```

properly solves this issue.

Related issues are #141 and #247.
