### PR TITLE
Allow for State of 0

### DIFF
--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -1059,7 +1059,7 @@ sub set_state_log {
     $target = '' unless defined $target;
     unshift(@{$$self{state_log}}, "$main::Time_Date $state set_by=$set_by_name"
       . (($target)?"target=$target":''))
-      if $state or (ref $self) eq 'Voice_Cmd';
+      if defined($state) or (ref $self) eq 'Voice_Cmd';
     pop @{$$self{state_log}} if $$self{state_log} and @{$$self{state_log}}
       > $main::config_parms{max_state_log_entries};
 

--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -2381,7 +2381,7 @@ sub html_item_state {
     my $filename     = $object->{filename};
     my $state_now    = $object->{state};
     my $html;
-    $state_now = '' unless $state_now; # Avoid -w uninitialized value msg
+    $state_now = '' unless defined($state_now); # Avoid -w uninitialized value msg
 
                                 # If >2 possible states, add a Select pull down form
     my @states;
@@ -2407,7 +2407,7 @@ sub html_item_state {
     if (my $h_icon = &html_find_icon_image($object, $object_type)) {
         $html .= qq[<img src="$h_icon" alt="$object_name" border="0"></a>];
     }
-    elsif ($state_now) {
+    elsif ($state_now ne '') {
 	my $temp = $state_now;
 	$temp = substr($temp, 0, 8) . '..' if length $temp > 8;
 	$html .= $temp . '</a>&nbsp';


### PR DESCRIPTION
Fixes two things:
- Allows for a State of 0 to be recorded in the state log
- Allows for a State of 0 to be displyed through the web interface rather than N/A

Both issues arise from the use of conditional statements such as:

```
if($state){...}
```

rather than using

```
if(defined($state)){...}
```

As a result a state of 0 was always ignored.
