### PR TITLE
Insteon: Change Hopcount Calculation to a Moving Average

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -271,17 +271,18 @@ sub default_hop_count
 		$$self{hop_sum} -= pop(@{$$self{hop_array}}) if (scalar(@{$$self{hop_array}}) >10);
 		$$self{default_hop_count} = int(($$self{hop_sum} / scalar(@{$$self{hop_array}})) + 0.5);
 
-		#Allow for per-device settings
-		$$self{default_hop_count} = $$self{max_hops} if ($$self{max_hops} &&
-			$$self{default_hop_count} > $$self{max_hops});
-		$$self{default_hop_count} = $$self{min_hops} if ($$self{min_hops} &&
-			$$self{default_hop_count} < $$self{min_hops});
-
 		::print_log("[Insteon::BaseObject] DEBUG4: ".$self->get_object_name
 			."->default_hop_count()=".$$self{default_hop_count}
 			." :: hop_array[]=". join("",@{$$self{hop_array}})) 
 			if $main::Debug{insteon} >= 4;
 	}
+
+	#Allow for per-device settings
+	$$self{default_hop_count} = $$self{max_hops} if ($$self{max_hops} &&
+		$$self{default_hop_count} > $$self{max_hops});
+	$$self{default_hop_count} = $$self{min_hops} if ($$self{min_hops} &&
+		$$self{default_hop_count} < $$self{min_hops});	
+	
         return $$self{default_hop_count};
 }
 


### PR DESCRIPTION
When I created the current hopcount calculation, I opted to use the highest count over the past 20 reported figures as the hopcount.  This often resulted in a higher than necessary hopcount.

@mstovenour modified that original code to use a running average.  After significant testing (both real world and using the new stress test) it is clear that using a running average results in a more reliable network.

**Of note**, the hopcount system has always relied on the hopcounts of incoming messages to determine the proper outgoing hopcount.  I have at least two devices on my network in which the hopcounts are highly asynchronous.  That is, where the outgoing and incoming hopcounts are very different.  If you have one of these instances, you should consider using the **min_hops()** and **max_hops()** routines for that device.
