### PR TITLE
Change Referenced to Web Cache Directory to html_alias_cache

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -736,7 +736,7 @@ sub setup {
                                 # Make various directories, if missing
     mkdir ("$config_parms{data_dir}/logs", 0777)         unless -d "$config_parms{data_dir}/logs";
     mkdir ("$config_parms{data_dir}/web", 0777)          unless -d "$config_parms{data_dir}/web";
-    mkdir ("$config_parms{data_dir}/cache", 0777)        unless -d "$config_parms{data_dir}/cache";
+    mkdir ("$config_parms{html_alias_cache}", 0777)        unless -d "$config_parms{html_alias_cache}";
     mkdir ("$config_parms{html_dir}/tv", 0777)           unless -d "$config_parms{html_dir}/tv";
     mkdir ("$config_parms{html_dir}/tv/clicktv", 0777)   unless -d "$config_parms{html_dir}/tv/clicktv";
 
@@ -3819,7 +3819,7 @@ sub play {
                                 # Let the speak code push the wav file
                                 # For speak (TTS), this gets done in Voice_Text.pm
         if ($parms{address}) {
-            copy $file, "$config_parms{data_dir}/cache/speak_address.$Second.wav";
+            copy $file, "$config_parms{html_alias_cache}/speak_address.$Second.wav";
             for my $address (split ',', $parms{address}) {
                 my $address_code = $config_parms{voice_text_address_code};
                 $address_code =~ s|\$address|$address|;

--- a/code/common/mh_control.pl
+++ b/code/common/mh_control.pl
@@ -529,14 +529,12 @@ sub handle_repeat_last_spoken_state() {
 # Clear the web cache directory
 $v_clear_cache = new Voice_Cmd 'Clear the web cache directory', '';
 $v_clear_cache->set_info(
-    'Delete all the auto-generated .jpg files in mh/web/cache');
+    'Delete all the auto-generated .jpg files in html_alias_cache directory');
 $v_clear_cache->tie_event('&handle_clear_cache_state()'); # noloop
 sub handle_clear_cache_state() {
     my $cmd = ($OS_win) ? 'del' : 'rm';
-    $cmd .= " $config_parms{html_dir}/cache/*.jpg";
-    $cmd =~ s|/|\\|g if $OS_win;
-    system $cmd;
-    $cmd .= " $config_parms{html_dir}/cache/*.wav";
+    $cmd .= " $config_parms{html_alias_cache}/*.jpg";
+    $cmd .= " $config_parms{html_alias_cache}/*.wav";
     $cmd =~ s|/|\\|g if $OS_win;
     system $cmd;
     print_log "Ran: $cmd";

--- a/code/public/whole_house_audio_speech.pl
+++ b/code/public/whole_house_audio_speech.pl
@@ -254,7 +254,7 @@ sub pre_speak_hook {
    print_log "Speech: player string is: $player_str";
    if ($player_str) {
       $SpeechCount++;
-      $parms->{'to_file'} = "$config_parms{data_dir}/cache/speak_festival.${Hour}.${Minute}.${Second}.${SpeechCount}.wav";
+      $parms->{'to_file'} = "$config_parms{html_alias_cache}/speak_festival.${Hour}.${Minute}.${Second}.${SpeechCount}.wav";
       $parms->{'use_players'} = $player_str;
    } else {
       $parms->{'no_speak'} = 1;
@@ -282,7 +282,7 @@ sub post_speak_hook {
 #####################################################################
 
 if ($New_Hour) {
-   system('find', "$config_parms{data_dir}/cache", '-mmin', '+5', '-exec', 'rm', '-f', '{}', ';');
+   system('find', "$config_parms{html_alias_cache}", '-mmin', '+5', '-exec', 'rm', '-f', '{}', ';');
 }
 
 if ($Reload) {

--- a/lib/Voice_Text.pm
+++ b/lib/Voice_Text.pm
@@ -134,7 +134,7 @@ sub speak_text {
     if ($parms{address}) {
         my @address = split ',', $parms{address};
         delete $parms{address};
-        $parms{to_file} = "$main::config_parms{html_dir}/cache/speak_address.$main::Second.wav";
+        $parms{to_file} = "$main::config_parms{html_alias_cache}/speak_address.$main::Second.wav";
 
         &speak_text(%parms);
         package main;   # So the we do not have to use $main::

--- a/web/bin/ListManager.pl
+++ b/web/bin/ListManager.pl
@@ -1298,7 +1298,7 @@ Please contact about any problems or suggestions via the misterhouse mailing lis
 #  ======================== POD END ==================================
 ];
 
-   open DOC, "echo \"$POD\" | pod2html --cachedir=$config_parms{data_dir}/cache --flush 2>/dev/null |";
+   open DOC, "echo \"$POD\" | pod2html --cachedir=$config_parms{html_alias_cache} --flush 2>/dev/null |";
    my $content = 0;
    while (<DOC>) {
       $content = 1 if /<body/;

--- a/web/bin/button.pl
+++ b/web/bin/button.pl
@@ -32,7 +32,7 @@ $image_file =~ s/ *$//;           # Drop trailing blanks
 $image_file .= "_$type"  if $type;
 $image_file .= "_$state" if $state;
 $image_file =~ s/ /_/g;           # Blanks in file names are nasty
-$image_file = "/cache/$image_file.jpg";
+$image_file = "/$image_file.jpg";
 
 # Set to 1 if you'd like to disable the image cache. Normally you should
 # not need to do this because it affects performance (MisterHouse needs
@@ -41,11 +41,11 @@ $image_file = "/cache/$image_file.jpg";
 # time the button generation script (this script) is called.
 my $nocache = 0;
 
-if (-e "$config_parms{data_dir}$image_file" && !$nocache) {
-    return $image_file if $file_name_only;
+if (-e "$config_parms{html_alias_cache}$image_file" && !$nocache) {
+    return "/cache".$image_file if $file_name_only;
 #   print "Returning data from: $image_file\n";
-    my $data = file_read "$config_parms{data_dir}$image_file";
-    return &mime_header($image_file, 1, length $data) . $data;
+    my $data = file_read "$config_parms{html_alias_cache}$image_file";
+    return &mime_header("/cache".$image_file, 1, length $data) . $data;
 }
 
                                 # Look for an icon
@@ -185,9 +185,9 @@ my $white = $image->colorClosest(255,255,255);
 $image->transparent($white);
 
                                 # Write out a copy to the cache
-print "Writing image to cache: $config_parms{data_dir}$image_file\n";
+print "Writing image to cache: $config_parms{html_alias_cache}$image_file\n";
 my $jpeg = $image->jpeg;
-file_write "$config_parms{data_dir}$image_file", $jpeg;
+file_write "$config_parms{html_alias_cache}$image_file", $jpeg;
 
-return $image_file if $file_name_only;
-return &mime_header($image_file, 1, length $jpeg) . $jpeg;
+return "/cache".$image_file if $file_name_only;
+return &mime_header("/cache".$image_file, 1, length $jpeg) . $jpeg;

--- a/web/bin/button2.pl
+++ b/web/bin/button2.pl
@@ -78,15 +78,15 @@ my $ImageFile = $Text . "_" . $Name;
 $ImageFile =~ s/^\$//;    # Drop leading blank on object name
 $ImageFile =~ s/ *$//;    # Drop trailing blanks
 $ImageFile =~ s/ /_/g;    # Blanks in file names are nasty
-$ImageFile = "/cache/$ImageFile.$ButtonType";
+$ImageFile = "/$ImageFile.$ButtonType";
 
 print "$ScriptName: Cache file should be $config_parms{data_dir}/$ImageFile\n" if $Debug{$ScriptName};
 
 # We hit the cache, so we give back the image and exit
-if ( -f "$config_parms{data_dir}/$ImageFile" ) {
-   print "$ScriptName: Hit cached file $config_parms{data_dir}/$ImageFile\n" if $Debug{$ScriptName};
-   my $data = file_read("$config_parms{data_dir}$ImageFile");
-   return &mime_header( $ImageFile, 1, length $data ) . $data;
+if ( -f "$config_parms{html_alias_cache}/$ImageFile" ) {
+   print "$ScriptName: Hit cached file $config_parms{html_alias_cache}/$ImageFile\n" if $Debug{$ScriptName};
+   my $data = file_read("$config_parms{html_alias_cache}$ImageFile");
+   return &mime_header( "/cache".$ImageFile, 1, length $data ) . $data;
 }
 print "$ScriptName: Cache file not found\n" if $Debug{$ScriptName};
 
@@ -306,13 +306,13 @@ if ($GDTemplate) {
    }
    my $ButtonFile = $GDTemplate->$ButtonType();
    if ( $ButtonOK ) {
-   print "$ScriptName: Writing button to cache: $config_parms{data_dir}/$ImageFile\n" if $Debug{$ScriptName};
-   file_write( "$config_parms{data_dir}/$ImageFile", $ButtonFile );
+   print "$ScriptName: Writing button to cache: $config_parms{html_alias_cache}/$ImageFile\n" if $Debug{$ScriptName};
+   file_write( "$config_parms{html_alias_cache}/$ImageFile", $ButtonFile );
    } else {
-   print "$ScriptName: Button $config_parms{data_dir}/$ImageFile not written to cache\n";
+   print "$ScriptName: Button $config_parms{html_alias_cache}/$ImageFile not written to cache\n";
    }
 
-   return &mime_header( $ImageFile, 1, length $ButtonFile ) . $ButtonFile;
+   return &mime_header( "/cache".$ImageFile, 1, length $ButtonFile ) . $ButtonFile;
 }
 else {
    print "$ScriptName: Error generating image\n";

--- a/web/bin/resizephoto.pl
+++ b/web/bin/resizephoto.pl
@@ -20,7 +20,7 @@ $image_file =~ s/(.+)\.(.+)$/$1/;
 my $img;
 my $nocache = 0;
 #$nocache = 1;
-$image_file = "$config_parms{data_dir}/cache/$image_file.jpg";
+$image_file = "$config_parms{html_alias_cache}/$image_file.jpg";
 unless (-e "$image_file" or $nocache) {
 	$url = $config_parms{html_alias_photos} .$url;
 	my $image = Image::Resize->new($url);

--- a/web/cache/empty_file.txt
+++ b/web/cache/empty_file.txt
@@ -1,5 +1,0 @@
-
-This is an empty file :)
-
-Put here to make sure unzip programs will re-created this directory.
-


### PR DESCRIPTION
html_alias_cache is defined as data_dir/cache by default.  Most installations will only require the data_dir to be defined, only those with special installations would need the cache dir to be outside the data_dir.

Closes #229
