### PR TITLE
Insteon: Reset ALDB Scan Time on Completed Successful Scan Only

### DIFF
--- a/lib/Insteon/AllLinkDatabase.pm
+++ b/lib/Insteon/AllLinkDatabase.pm
@@ -152,6 +152,8 @@ sub query_aldb_delta
 		#if we just did a aldb_query less than 2 seconds ago, don't repeat
 		&::print_log("[Insteon::AllLinkDatabase] The link table for "
 			. $self->{device}->get_object_name . " is in sync.");
+		#Further extend Scan Time in case of serial aldb requests
+		$self->scandatetime(&main::get_tickcount);
 		if (defined $self->{_aldb_unchanged_callback}) {
 			package main;
 			my $callback = $self->{_aldb_unchanged_callback};
@@ -288,7 +290,6 @@ sub scan_link_table
 	$$self{_mem_activity} = 'scan';
 	$$self{_success_callback} = ($success_callback) ? $success_callback : undef;
 	$$self{_failure_callback} = ($failure_callback) ? $failure_callback : undef;
-	$self->scandatetime(&main::get_tickcount);
 	$self->health('out-of-sync'); # allow acknowledge to set otherwise
 	if($self->isa('Insteon::ALDB_i1')) {
 		$self->_peek('0FF8',0);
@@ -2715,7 +2716,6 @@ Sends the request for the first alllink entry on the PLM.
 sub get_first_alllink
 {
 	my ($self) = @_;
-        $self->scandatetime(&main::get_tickcount);
         $self->health('out-of-sync'); # set as corrupt and allow acknowledge to set otherwise
 	$$self{device}->queue_message(new Insteon::InsteonMessage('all_link_first_rec', $$self{device}));
 }

--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -675,6 +675,8 @@ sub _is_info_request
 			if ($self->_aldb->aldb_delta() eq $msg{cmd_code}){
 				&::print_log("[Insteon::BaseObject] The link table for "
 					. $self->{object_name} . " is in sync.");
+				#Link Table Scan Successful, Record Current Time
+				$self->_aldb->scandatetime(&main::get_tickcount);
 				if (defined $self->_aldb->{_aldb_unchanged_callback}) {
 					$callback = $self->_aldb->{_aldb_unchanged_callback};
 					$self->_aldb->{_aldb_unchanged_callback} = undef;

--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -567,6 +567,7 @@ sub _parse_data {
                                                 {
                                                 	$self->_aldb->health("good");
                                                 }
+                                                $self->_aldb->scandatetime(&main::get_tickcount);
 						&::print_log("[Insteon_PLM] " . $self->get_object_name 
 							. " completed link memory scan: status: " . $self->_aldb->health())
 							if $main::Debug{insteon};


### PR DESCRIPTION
Previously we reset when we started a scan

Now we reset when a scan has completed successfully and each time when the device tells us that the ALDB Delta has not changed.

We also reset if serial query_aldb_delta requests are received in less than 2 seconds.  This allows for sequentail aldb actions without slowing down to send a request to the device for its ALDB Delta when it is unlikely that it changed.
