### PR TITLE
Insteon_RemoteLinc: Fix for Setting Linked Devices

### DIFF
--- a/lib/Insteon/Controller.pm
+++ b/lib/Insteon/Controller.pm
@@ -54,7 +54,7 @@ package Insteon::RemoteLinc;
 use strict;
 use Insteon::BaseInsteon;
 
-@Insteon::RemoteLinc::ISA = ('Insteon::BaseDevice','Insteon::DeviceController');
+@Insteon::RemoteLinc::ISA = ('Insteon::DeviceController','Insteon::BaseDevice');
 
 my %message_types = (
 	%Insteon::BaseDevice::message_types,


### PR DESCRIPTION
Needed to set DeviceController as the primary, this underscores the need to get rid of that package.
