### PR TITLE
Insteon: All_Link Cleanup Check for Active Message

### DIFF
--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -815,7 +815,7 @@ sub _parse_data {
                         	my $message_to_string = ($self->active_message) ? $self->active_message->to_string() : "";
 				&::print_log("[Insteon_PLM] Received all-link cleanup success: $message_to_string")
                                 	if $main::Debug{insteon};
-				if (ref $self->active_message->setby){
+				if (ref $self->active_message && ref $self->active_message->setby){
 					my $object = $self->active_message->setby;
 					$object->is_acknowledged(1);
 					$object->_process_command_stack();


### PR DESCRIPTION
Before calling setby on the active_message, make sure that an active message exists.
