### PR TITLE
Fix web_hook parameter passing, commonly used in Audrey speech.

### DIFF
--- a/code/common/speech_clash.pl
+++ b/code/common/speech_clash.pl
@@ -38,41 +38,46 @@ $sc_delay	= 2	unless $sc_delay;
 sub speak_clash_stub {
    my ($ref) = @_;
    &print_log("Clash control stub called!") if $main::Debug{voice};
-   if (1 == &Voice_Text::is_speaking() && $$ref{to_file} eq '') {
+   if (1 == &Voice_Text::is_speaking() && $ref->{to_file} eq '') {
       if ($main::Debug{voice}) {
-         $$ref{clash_retry}=0 unless $$ref{clash_retry};
-         $$ref{clash_retry}++; #To track how many loops are made
-	 &print_log("SPEAK CLASH($$ref{clash_retry}): Delaying speech call for " . $$ref{text} . "\n");
+         $ref->{clash_retry}=0 unless $ref->{clash_retry};
+         $ref->{clash_retry}++; #To track how many loops are made
+	 &print_log("SPEECH_CLASH($ref->{clash_retry}): Delaying speech call for " . $ref->{text} . "\n");
       }
-      $$ref{nolog}=1;       #To stop MH from logging the speech again
+      $ref->{nolog}=1;       #To stop MH from logging the speech again
+      delete($ref->{web_hook});
+      delete($ref->{audreySpeakRooms});
 
 #Method One:
       my $parmstxt;
       my ($pkey,$pval);
+      
       while (($pkey,$pval) = each(%{$ref})) {
          $parmstxt.=', ' if $parmstxt;
 			# WLA: quote the text, otherwise if the spoken text contains a ' character we
 			# get an error message
          $parmstxt .= "$pkey => q($pval)";
       }
-      &print_log("CLASH Parameters: $parmstxt") if $main::Debug{voice};
-      &run_after_delay($sc_delay, "speak($parmstxt)");
+      &print_log("SPEECH_CLASH Parameters: $parmstxt") if $main::Debug{voice};
+      &run_after_delay($sc_delay, "speak(".$parmstxt.")");
 
 #Method Two - Doesn't work :(
 #      run_after_delay $sc_delay, sub {&speak(%{$ref})}; #Doesn't work :(
 
-      $$ref{no_speak}=1;    #To stop MH from speaking this time around
+      $ref->{no_speak}=1;    #To stop MH from speaking this time around
       return;
    }
 
-   if ($$ref{clash_retry}) {
-      &print_log("SPEAK CLASH: Resolved, continuing speech.");# if $main::Debug{voice};
+   if ($ref->{clash_retry}) {
+      &print_log("SPEECH_CLASH: Resolved, continuing speech.");# if $main::Debug{voice};
       $is_speaking=0;
       $is_speaking_flag=0;
    }
 }
-
-&Speak_parms_add_hook(\&speak_clash_stub) if $Reload;
+if ($Reload) {
+    print_log("SPEECH_CLASH: Hooking into speech events");
+    &Speak_parms_add_hook(\&speak_clash_stub);
+}
 
 =begin comment
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@


### PR DESCRIPTION
Removed web_hook and audreySpeakRooms parameters to the speak call when delaying, since they cause errors, and will be created on the next call after a delay anyhow. This fixes an issue when used with audrey speech.

Also changed variable references to -> style (just my current preference).
