### PR TITLE
Insteon: Prevent Success Callback from Running on Get Engine NACK

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -1886,6 +1886,8 @@ sub _get_engine_version_failure
 			."linked; Please use 'link to interface' voice command");
 		$self->engine_version('I2CS');
 	}
+	#Clear success callback, otherwise it will run when message is cleared
+	$self->interface->active_message->success_callback('0');
 }
 
 =item C<ping([count])>

--- a/lib/Insteon/Message.pm
+++ b/lib/Insteon/Message.pm
@@ -113,7 +113,7 @@ Data will be evaluated after the receipt of an ACK from the device for this comm
 sub success_callback
 {
 	my ($self, $callback) = @_;
-        if ($callback)
+        if (defined $callback)
         {
         	$$self{success_callback} = $callback;
         }


### PR DESCRIPTION
Both the success callback and the failure callback were being called on an i2CS device when using the command link to interface.
