### PR TITLE
Insteon: KeyPadLinc Subgroups Derive Link State is Not Dimmable

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -443,6 +443,7 @@ sub set_receive
 	my ($self, $p_state, $p_setby, $p_response) = @_;
 	my $curr_milli = sprintf('%.0f', &main::get_tickcount);
 	my $window = 1000;
+	$p_state = $self->derive_link_state($p_state);
 	if (($p_state eq $self->state || $p_state eq $self->state_final)
 		&& ($curr_milli - $$self{set_milliseconds} < $window)){
 		::print_log("[Insteon::BaseObject] Ignoring duplicate set " . $p_state .
@@ -3135,8 +3136,8 @@ sub set_linked_devices
 					# remember the current state to support resume
 					$$self{members}{$member_ref}{resume_state} = $light->state;
 					$member->manual($light, $ramp_rate);
-					if ($light->can('derive_link_state') && lc $link_state ne 'on'){
-						$local_state = $light->derive_link_state($link_state);
+					if (lc $link_state ne 'on'){
+						$local_state = $light->$link_state;
 					}
 					$light->set_receive($local_state,$self);
 				}
@@ -3153,7 +3154,7 @@ sub set_linked_devices
 				# if they are Insteon_Device objects, then simply set_receive their state to
 				#   the member on level
 				if (lc $link_state ne 'on'){
- 					$local_state = $member->derive_link_state($link_state);
+ 					$local_state = $link_state;
 				}
 				$member->set_receive($local_state,$self);
 			}

--- a/lib/Insteon/Lighting.pm
+++ b/lib/Insteon/Lighting.pm
@@ -986,6 +986,18 @@ sub get_voice_cmds
     return \%voice_cmds;
 }
 
+# The subgroup items are not dimmable, so call BaseInsteon for them
+
+sub derive_link_state
+{
+	my ($self, $p_state) = @_;
+	if ($self->group eq '01'){
+		return $self->SUPER::derive_link_state($p_state);
+	} else {
+		return $self->Insteon::BaseObject::derive_link_state($p_state);
+	}
+}
+
 =back
 
 =head2 AUTHOR


### PR DESCRIPTION
The subgroups are not dimmable
