### PR TITLE
Insteon: Re-enable off_fast and on_fast in dimmable lights

### DIFF
--- a/lib/Insteon/Lighting.pm
+++ b/lib/Insteon/Lighting.pm
@@ -187,9 +187,8 @@ sub derive_link_state
 	}
 	
 	my $link_state = 'on';
-	if ($p_state eq 'off' or $p_state eq 'off_fast')
-	{
-		$link_state = 'off';
+	if (grep(/$p_state/i, @{['on_fast', 'off', 'off_fast']})) {
+		$link_state = $p_state;
 	}
 	elsif ($p_state =~ /\d+%?/)
 	{


### PR DESCRIPTION
Accidentally dropped this feature when the new set routine was merged.
