### PR TITLE
Scene_Builder: Dereference Hashes for Backwards Compatibility in Perl

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -1085,10 +1085,10 @@ sub read_table_finish_A {
 
         #Loop through the controller hash
         if (exists $scene_build_controllers{$scene}){
-	        foreach my $scene_controller (keys $scene_build_controllers{$scene}) {
+	        foreach my $scene_controller (keys %{$scene_build_controllers{$scene}}) {
 	            if ($objects{$scene_controller}) {
 	            	#Make a link to each responder in the responder hash
-	                while (my ($scene_responder, $responder_data) = each($scene_build_responders{$scene})) {
+	                while (my ($scene_responder, $responder_data) = each(%{$scene_build_responders{$scene}})) {
 	                    my ($on_level, $ramp_rate) = split(',', $responder_data);
 	
 	                    if (($objects{$scene_responder}) and ($scene_responder ne $scene_controller)) {


### PR DESCRIPTION
http://stackoverflow.com/questions/10979486/perl-incompatibility-issue-with-each-in-a-hash-of-hashes-5-14-5-8-8

as discovered by @CityDweller
