### PR TITLE
fixed to work with newer MH and perl5. Added trending of barom the wm2 d...

### DIFF
--- a/lib/Weather_daviswm2.pm
+++ b/lib/Weather_daviswm2.pm
@@ -344,7 +344,7 @@ sub process{
 		);
 	}
 	
-	$$wptr{TempIndoor}=$indoor_temp-3;
+	$$wptr{TempIndoor}=$indoor_temp;
 	$$wptr{TempOutdoor}=$outdoor_temp;
 	$$wptr{DewIndoor}=$indoor_dewpoint;
 	$$wptr{DewOutdoor}=$outdoor_dewpoint; 
@@ -359,7 +359,6 @@ sub process{
 	$$wptr{RainTotal}=$total_rain;
 	$$wptr{RainRate}=$rain_rate;
 	$$wptr{BaromDelta}=$barom_tendency;
-	$$wptr{Conditions}="rain";
 
 	if ($::Debug{weather}) {
 		foreach my $key qw(


### PR DESCRIPTION
I was not able to get my wm2 to work on the newer MH on git in master.  It worked fine on old mh perl4 system. 

Let me know any patterns I used are going to cause any problems or if other fixes need to be made and I will adjust till this is ready to merge.

Fixes.
  The cron was broken and caused errors.
  The serial reading was broken added a chr() to fix the casting that does not work in perl5 
  The debugging flag was changed to lower case 'weather' to match other modules usage

Added 
  Barometer trending analysis
