### PR TITLE
Allow End of Line Comments in CODE Definition

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -4778,7 +4778,6 @@ sub read_table_files {
                     print TABLE_OUT $_;
                     next;
                 }
-                $_ =~ s/#.*//;      # Strip off comments                                                
                 next if (/^\s*$/);  # Skip blank lines
         }
             if ($format) {

--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -29,6 +29,7 @@ sub read_table_init_A {
 
 sub read_table_A {
     my ($record) = @_;
+    my $record_raw = $record;
     
     if($record =~ /^#/ or $record =~ /^\s*$/) {
        return;
@@ -275,7 +276,7 @@ sub read_table_A {
     }
     elsif($type eq "CODE") {
 	# This is for simple one line additions such as setting an attribute or adding an image.
-	($object) = "$record" =~ /CODE,\s+(.*)/;
+	($object) = "$record_raw" =~ /CODE,\s+(.*)/;
 	$code = "$object\n";
 	$object = '';
     }


### PR DESCRIPTION
This change permits end of line commnents on CODE definitions to be carried through the the mhp file.

Specifically, and likely most usefully, this allows #noloop commands to be respected at the end of CODE defintions such as:

```
CODE, $garage_door->tie_event($garage_light->set(ON), ON); #noloop
```
