### PR TITLE
xPL messages generate invalid msg-type

### DIFF
--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -1117,7 +1117,7 @@ sub reset_states2 {
                    {name => $$ref{object_name}, state => $state, state_prev => $$ref{state_prev}, set_by => $set_by, mh_target => $target});
     }
     if ($send_xpl and $set_by !~ /^xpl/i) {
-        &xPL::sendXpl('mhouse.item', 'xpl-stat', 'mhouse.item' =>
+        &xPL::sendXpl('mhouse.item', 'stat', 'mhouse.item' =>
                    {name => $$ref{object_name}, state => $state, state_prev => $$ref{state_prev}, set_by => $set_by, mh_target => $target});
     }
 


### PR DESCRIPTION
The Generic_Item code is calling sendXpl with the message type of
"xpl-stat",  however sendXpl adds the xpl- prefix as well, resulting in
an invalid message type.

The xPL4Linux hub appears to reject the message because of a missing Device ID.   I'm not sure if that's a hub issue or something with the generated message.
