### PR TITLE
Insteon_Thermo: Process Device Cmd Stack on Msg Ack

### DIFF
--- a/lib/Insteon/Thermostat.pm
+++ b/lib/Insteon/Thermostat.pm
@@ -423,6 +423,7 @@ sub _process_message
 			"for ". $self->get_object_name) if $self->debuglevel(1, 'insteon');	
 		$self->_cool_sp((hex($msg{extra})/2));
 		$clear_message = 1;
+		$self->_process_command_stack(%msg);
 	}
 	elsif ($msg{command} eq "thermostat_setpoint_heat" && $msg{is_ack}){
 		$self->default_hop_count($msg{maxhops}-$msg{hopsleft});
@@ -430,6 +431,7 @@ sub _process_message
 			"for ". $self->get_object_name) if $self->debuglevel(1, 'insteon');	
 		$self->_heat_sp((hex($msg{extra})/2));
 		$clear_message = 1;
+		$self->_process_command_stack(%msg);
 	}
 	elsif ($$self{_zone_action} eq 'setpoint' && $$self{m_pending_setpoint}) {
 		$self->default_hop_count($msg{maxhops}-$msg{hopsleft});
@@ -440,6 +442,7 @@ sub _process_message
 		$$self{m_setpoint_pending} = 0;
 		$$self{_zone_action} = undef;
 		$clear_message = 1;
+		$self->_process_command_stack(%msg);
 	} else {
 		$clear_message = $self->SUPER::_process_message($p_setby,%msg);
 	}


### PR DESCRIPTION
Failed to include proper calls to _process_command_stack in the Insteon::Thermostat::_process_message routine.

This likely has little effect on i2CS thermostats that had broadcast messages enabled because the thermostat immediatley issued a broadcast command which would cause MH to process the command stack.

However, i1 devices or i2cs devices without broadcast enabled, may have become "locked up" within MH after the issuance of a setpoitn change.
