### PR TITLE
X10: Retry if Message is Not Acked by PLM

### DIFF
--- a/lib/Insteon/BaseInterface.pm
+++ b/lib/Insteon/BaseInterface.pm
@@ -380,7 +380,7 @@ sub process_queue
                                        	$failed_message->setby->fail_count_log(1) 
                                        		if $failed_message->setby->can('fail_count_log');
 				}
-				else
+				elsif (!$failed_message->isa('Insteon::X10Message'))
 				{
 					&main::print_log("[Insteon::BaseInterface] WARN! Unable to clear acknowledge for "
 						. ((defined($failed_message->setby)) ? $failed_message->setby->get_object_name : "undefined"));

--- a/lib/Insteon/Message.pm
+++ b/lib/Insteon/Message.pm
@@ -232,7 +232,7 @@ sub send
         	if ($self->send_attempts > 0)
                 {
 			if ((ref $self->setby && $self->setby->debuglevel(1, 'insteon')) ||
-				((!ref $self->setby) && ::Debug{'insteon'})){
+				((!ref $self->setby) && $::Debug{'insteon'})){
 				::print_log("[Insteon::BaseMessage] WARN: now resending "
 				. $self->to_string() . " after " . $self->send_attempts
 				. " attempts.");

--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -400,6 +400,7 @@ sub _send_cmd {
 		. sprintf('%.2f',$incurred_delay_time) . " seconds") if $self->debuglevel(2, 'insteon');
         	$command = $prefix{x10_send} . $command;
 		$delay = $$self{xmit_x10_delay};
+		$self->_set_timeout('command', '1000'); # a commmand needs to be PLM ack'd w/i 1 seconds or a retry is attempted
                 # clear command timeout so that we don't wait for an insteon ack before sending the next command
 	} else {
                 my $command_type = $message->command_type;
@@ -409,7 +410,7 @@ sub _send_cmd {
                 $command = $prefix{$command_type} . $command;
                 if ($command_type eq 'all_link_send' or $command_type eq 'insteon_send' or $command_type eq 'insteon_ext_send' or $command_type eq 'all_link_direct_cleanup')
                 {
-         		$self->_set_timeout('command', $cmd_timeout); # a commmand needs to be PLM ack'd w/i 3 seconds or it gets dropped
+         		$self->_set_timeout('command', $cmd_timeout); # a commmand needs to be ack'd by device w/i $cmd_timeout or a retry is attempted
                 }
         }
 	my $is_extended = ($message->can('command_type') && $message->command_type eq "insteon_ext_send") ? 1 : 0;
@@ -545,6 +546,7 @@ sub _parse_data {
                                         #   AND if the current, pending message is the X10 message
 					if (($parsed_data =~ /$prefix{x10_send}\w{4}06/) && ($pending_message->isa('Insteon::X10Message')))
                                         {
+                				$self->_clear_timeout('command');
                 				$self->clear_active_message();
 					}
 


### PR DESCRIPTION
If the PLM fails to ACK an X10 message, retry sending it again after 1 second.  This change will respect the PLM_retry_count.
