### PR TITLE
Updates and fixes for weather_pollen.pl

### DIFF
--- a/code/common/weather_pollen.pl
+++ b/code/common/weather_pollen.pl
@@ -1,11 +1,11 @@
 #Category=Weather
 
-#@ This module gets the pollen forecast from wunderground.com and puts the pollen
+#@ This module gets the pollen forecast from Claritin.com and puts the predominant pollen
 #@ type and pollen count into the %Weather hash.
 #@
 #@ Uses mh.ini parameter zip_code
 
-# Get pollen count forecast from wunderground.com and put it and the pollen
+# Get pollen count forecast from Claritin.com and put it and the predominant pollen
 # type into the %Weather hash.
 # Technically there is a 4 day forecast, but I have seen it vary so widely
 # from day 2 and what day 1 will say tomorrow that I don't count on it for
@@ -14,13 +14,13 @@
 #uses mh.ini parameter zip_code=
 #
 #info from:
-#http://www.wunderground.com/DisplayPollen.asp?Zipcode=64119
+#http://www.claritin.com/weatherpollenservice/weatherpollenservice.svc/getforecast/64119
 #
 
 # weather_pollen.pl
 # Original Author:  Kent Noonan
 # Revision:  1.3
-# Date:  07/12/2014
+# Date:  07/14/2014
 
 =begin comment
 
@@ -30,47 +30,43 @@
      David J. Mark - 06/12/2006
  1.2 Updated to use new Trigger design.
      Bruce Winter - 06/25/2006
- 1.3 Updated to use Wunderground instead of Pollen.com because
-     Pollen.com has added annoying countermeasures to prevent
-     screenscraping that would take much more code to parse.  Plus,
-     their encryption scheme could change at anytime, breaking the
-     script again.  Wunderground is perfect in this case because the data is
-     much easier to scrape and they actually receive their pollen data from
-     Pollen.com anyway.  I've also done some general cleanup & added
-     a log message to warn if parsing fails.
-     Jared J. Fernandez - 07/12/2014
+ 1.3 Updated to use the JSON WeatherPollenService from Claratin.com
+     since Pollen.com has added countermeasures to prevent screenscraping
+     that would take much more code to parse.  The WeatherPollenService
+     has a better API that seems to provide the same data as most other
+     online pollen forecasting services.  In addition to switching service
+     providers, I've also done some general cleanup & improvements.
+     Jared J. Fernandez - 07/14/2014
 
 =cut
 
+use JSON qw( decode_json );
+
+my $pollen_file = "$config_parms{data_dir}/web/pollen_forecast.json";
+
 $v_get_pollen_forecast = new Voice_Cmd('[Get,Check] pollen forecast');
-$v_get_pollen_forecast->set_info("Downloads and parses the pollen forecast page from wunderground.com.  The 'check' option reads out the result after parsing is complete.");
+$v_get_pollen_forecast->set_info("Downloads and parses the pollen forecast data.  The 'check' option reads out the result after parsing is complete.");
 
 $v_read_pollen_forecast = new Voice_Cmd('Read pollen forecast');
-$v_read_pollen_forecast->set_info("Reads out the previously fetched pollen forecast");
+$v_read_pollen_forecast->set_info("Reads out the previously fetched pollen forecast.");
 
-$p_pollen_forecast = new Process_Item("get_url http://www.wunderground.com/DisplayPollen.asp?Zipcode=$config_parms{zip_code} $config_parms{data_dir}/web/pollen_forecast.html");
+$p_pollen_forecast = new Process_Item("get_url http://www.claritin.com/weatherpollenservice/weatherpollenservice.svc/getforecast/$config_parms{zip_code} $pollen_file");
 
-&parse_pollen_forecast if $Reload;
+&parse_pollen_forecast if (($Reload) && (-e $pollen_file));
 
 sub parse_pollen_forecast {
-
-	my ($found1,$found2);
-	open(FILE,"$config_parms{data_dir}/web/pollen_forecast.html");
-	while (<FILE>) {
-		if ((/Pollen Type:<\/strong>\s(\w+)\.<\/h3>/) && (!defined($found1))) {
-			$found1 = 1;
-			$main::Weather{TodayPollenType}=$1;
-		} elsif ((/<p>(\d+\.\d+)<\/p>/) && (!defined($found2))) {
-			$found2 = 1;
-			$main::Weather{TodayPollenCount}=$1;
-		}
-		last if ($found1 && $found2);
+	my @pollen_data = file_read($pollen_file) || warn "Unable to open pollen data file.";
+	# The JSON file that is retuned by the service is malformed; these substitutions clean it up so that the perl JSON module can parse it.
+	for (@pollen_data) {
+		s/\"\{/\{/;
+		s/\\//g;
+		s/\}\"/\}/;
 	}
-	close(FILE);
-	unless ($found1 && $found2) {
-		warn "Error parsing pollen info.";
-	}
-
+	my $json = decode_json(@pollen_data) || warn "Error parsing pollen info from file.";
+	$main::Weather{TodayPollenCount} = $json->{pollenForecast}{forecast}[0];
+	$main::Weather{TomorrowPollenCount} = $json->{pollenForecast}{forecast}[1];
+	$main::Weather{TodayPollenType} = $json->{pollenForecast}{pp};
+	$main::Weather{TodayPollenType} =~ s/\.//;
 }
 
 if ($state = said $v_get_pollen_forecast) {
@@ -84,10 +80,8 @@ if (done_now $p_pollen_forecast){
 		$v_get_pollen_forecast->respond("app=pollen Today's pollen count is $main::Weather{TodayPollenCount}. The predominant pollens are from " . lc($main::Weather{TodayPollenType} . "."));
 	}
 	else {
-		$v_get_pollen_forecast->respond("app=pollen Pollen forecast retrieved");
+		$v_get_pollen_forecast->respond("app=pollen Pollen forecast retrieved.");
 	}
-
-
 }
 
 if (said $v_read_pollen_forecast) {


### PR DESCRIPTION
Fixes Issue #431.

While it would be possible to decode the forecast number from Pollen.com, it will require much more code and if they change the encryption scheme in the future (I've seen some accounts online where they have), the script will be broken again.  This pull changes the script to use Wunderground instead since their site is easier to parse and they actually get their pollen info from Pollen.com anyway.

I've also done some other general cleanup and made minor improvements to the script.
