### PR TITLE
Insteon/X10: Skip Calling Set_Receive on PLM

### DIFF
--- a/lib/X10_Items.pm
+++ b/lib/X10_Items.pm
@@ -424,7 +424,7 @@ sub set_receive {
     &set_x10_level($self, $state);
     $self->SUPER::set_receive($state, $set_by);
     $self->{interface}->set_receive($state, $set_by) 
-        unless $self->{interface}->isa('Insteon_PLM';
+        unless $self->{interface}->isa('Insteon_PLM');
 }
 
 =item C<set_x10_level>


### PR DESCRIPTION
Not clear on what this does for a general X10 interface, but the Insteon PLM has no state, therefore it has no set_receive command.  The safest thing to do is just to skip this call for Insteon PLMs.

Fixes hollie/misterhouse#434
