### PR TITLE
Fix Link Generation in Items and Modules Documenation Pages

### DIFF
--- a/bin/update_docs
+++ b/bin/update_docs
@@ -280,9 +280,11 @@ else {
 foreach my $doc ( keys %podfiles ) {
     my $podfile = "$docdir/$doc";
     my $ind     = "";
+    my $docdir2 = $docdir;
     if ( $doc eq "items.pod" or $doc eq "modules.pod" ) {
         $podfile = "$outdir/$doc";
         $ind     = "--noindex";
+        $docdir2 = '..';
     }
     $doc =~ s/\.pod$//i;
     my $htmlfile = "$outdir/$doc.html";
@@ -297,7 +299,7 @@ foreach my $doc ( keys %podfiles ) {
         pod2html(
             "--infile=$podfile",    "--outfile=$htmlfile",
             "--noheader",
-            "--htmldir=$outdir",    "--podroot=$docdir",
+            "--htmldir=$outdir",    "--podroot=$docdir2",
             "--podpath=.",          "--css=/lib/pod.css",
             $ind
         );

--- a/docs/mh.pod
+++ b/docs/mh.pod
@@ -369,13 +369,13 @@ These constants are defined, so we can use them without quoting them
 The Misterhouse documentation refers to perl objects as items.  Most
 of these are derived from L<Generic_Item|lib::Generic_Item>.
 
-The old list of items is L<here|::objects>.  These will be moved to the 
+The old list of items is L<here|objects>.  These will be moved to the 
 new list soon.
 
-The new list of items is L<here|::items>.  This documentation is maintained
+The new list of items is L<here|items>.  This documentation is maintained
 in the .pm files along side the code.
 
-The list of modules that are not items is L<here|::modules>.
+The list of modules that are not items is L<here|modules>.
 
 =head2 List of functions
 

--- a/web/lib/pod.css
+++ b/web/lib/pod.css
@@ -3,7 +3,7 @@ hr, big {
 }
 
 code {
-	font-family: "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
+	font-family: "Courier New", Courier, monospace;
 	font-weight: bold;      
 }
 


### PR DESCRIPTION
I don't know when or how this broke, but I made some changes to update_docs some months back.

I noticed that on my local copy, the links on the Items and Modules pages were non-existant.  This change fixes that.

I also made a change to the pod.css so that CODE tags are mono-spaced formatted.
