### PR TITLE
X10/Insteon: Cherry-Pick Former Commit That was Erroneously Reverted

### DIFF
--- a/lib/X10_Items.pm
+++ b/lib/X10_Items.pm
@@ -242,7 +242,6 @@ sub set_interface {
         } elsif ( defined $interface_object and $interface_object->isa('Insteon_PLM')) {
             print "[X10] for id $id, x10 interface supplied ($interface) and supported by an Insteon PLM\n" if $localDebug;
             $self->{interface} = $interface_object;
-            $self->{interface}->add($self);
         } else {
             # we can't find a real interface, so use a Dummy_Interface
             print "[X10] warning, using dummy interface for id $id and supplied interface $interface\n" if $localDebug;


### PR DESCRIPTION
Original commit message is below.

194cf56c2d46149b11d7a8732db41125991bc143

X10/Insteon: Remove Line Which Attempted to Add the X10 Device to the PLM

Symptoms: the PLM states parameter contained the entire hashes of any X10 devices.  This made get_states useless on the PLM (it should return an empty array). Instead it returned a bunch of garbage.  This further lead to crashed in the json and xml servers.

Cause: the $interface->add($X10_Object) command was calling the add subroutine in Device_Item.  I am not even sure how the inheritance allowed this to happen.  But this routine expected a list of states to be passed as the first parameter not an object.

Solution: Remove the offending call to add.  It is not clear why this was used (the commit notes demonstrate that this was added when support for X10 over Insteon was added).  Perhaps the drafter intended to add the X10 device as a member of the PLM?  However, the PLM itself has no members, PLM scenes are allowed to have members.  Alternatively, perhaps the drafter intended to add the object to the list maintained by InsteonManager? Adding some code to the X10_Item would allow this to work in theory, however it isn't clear to me why you would want this. The list is maintained so that the insteon_manager can assist in link management, something not done by X10 devices.  We have also been operating without adding the X10 items to the object list for quite some time without incident.  Indeed no current calls to find_members would even return an X10 device as they all specifiy Insteon packages.  Finally, perhaps this is some vestige of the old Insteon code.

Removing the offending line solves the issue, and does not appear to have any adverse effects.
