### PR TITLE
Insteon: Prevent Error Cause by Using old Read Table A Defintion

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -161,6 +161,9 @@ sub interface
 {
 	my ($self,$p_interface) = @_;
         if (defined $p_interface) {
+        	if (ref $p_interface ne 'Insteon_PLM'){
+        		$p_interface = ::get_object_by_name($p_interface);
+        	}
 		$$self{interface} = $p_interface;
         }
         elsif (!($$self{interface}))


### PR DESCRIPTION
Using an old definition such as:

```
INSTEON_MOTIONSENSOR, DE.AD.BE, Garage_Motion, MotionSensors|hidden, PLM, 1001
```

Would cause an error, as discovered by @CityDweller.  This fixes that issue.
