### PR TITLE
Add squeezebox CLI support

### DIFF
--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -274,7 +274,7 @@ sub process_cli_response {
                     . $self->state() );
         }
     }
-    if ( ( $response =~ /pause 0/ ) ) {
+    if ( $response =~ /pause 0/ || $response =~ /playlist newsong/ ) {
 		# Removed the /^ requirement because the classic player reports 'playlist pause 0' instead of 'pause 0' like the radio does
         # Request the current mode if pause is 0
         $self->send_cmd("mode ?");

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -408,7 +408,7 @@ sub play_notification {
     $self->send_cmd("time ?");
 
     # Save the current playlist
-    $self->send_cmd("playlist save prenotification_playlist");
+    $self->send_cmd("playlist save prenotification_playlist_" . $self{object_name});
 
     # Set the repeat to none
     $self->send_cmd("playlist repeat 0");

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -1,3 +1,4 @@
+
 =head1 B<SqueezeboxCLI>
 
 =head2 SYNOPSIS
@@ -24,6 +25,7 @@ This module allows control over a player through the telnet command line interfa
 the server.
 
 =cut
+
 package SqueezeboxCLI;
 
 # Used solely to provide a consistent logging feature, copied from Nest.pm
@@ -36,13 +38,14 @@ my $info  = 2;
 my $trace = 3;
 
 sub debug {
-    my ($self, $message, $level) = @_;
+    my ( $self, $message, $level ) = @_;
     $level = 0 if $level eq '';
-    my $line = '';
+    my $line   = '';
     my @caller = caller(0);
-    if ($::Debug{'squeezeboxcli'} >= $level || $level == 0){
-        $line = " at line " . $caller[2] if $::Debug{'squeezeboxcli'} >= $trace;
-        ::print_log("[" . $caller[0] . "] " . $message . $line);
+    if ( $::Debug{'squeezeboxcli'} >= $level || $level == 0 ) {
+        $line = " at line " . $caller[2]
+            if $::Debug{'squeezeboxcli'} >= $trace;
+        ::print_log( "[" . $caller[0] . "] " . $message . $line );
     }
 }
 
@@ -50,116 +53,122 @@ package SqueezeboxCLI_Interface;
 
 use strict;
 
-@SqueezeboxCLI_Interface::ISA = ('Generic_Item', 'SqueezeboxCLI');
+@SqueezeboxCLI_Interface::ISA = ( 'Generic_Item', 'SqueezeboxCLI' );
 
 sub new {
-	my ($class, $server, $port, $user, $pass) = @_;
-	my $self = new Generic_Item();
-	bless $self, $class;
-	$$self{server} = $server;
-	$$self{port}   = $port || 9090;
-	$$self{login}  = $user . " " . $pass || "";
-	$$self{players} = {};
-	$$self{reconnect_timer} = new Timer;
-	$$self{squeezecenter} = new Socket_Item(undef, undef, $$self{server}. ":" . $$self{port}, "squeezecenter_cli", 'tcp', 'record');
-	$self->login();
-	::MainLoop_pre_add_hook(sub {$self->check_for_data();}, 'persistent');
-	return $self;
+    my ( $class, $server, $port, $user, $pass ) = @_;
+    my $self = new Generic_Item();
+    bless $self, $class;
+    $$self{server}          = $server;
+    $$self{port}            = $port || 9090;
+    $$self{login}           = $user . " " . $pass || "";
+    $$self{players}         = {};
+    $$self{reconnect_timer} = new Timer;
+    $$self{squeezecenter}
+        = new Socket_Item( undef, undef, $$self{server} . ":" . $$self{port},
+        "squeezecenter_cli", 'tcp', 'record' );
+    $self->login();
+    ::MainLoop_pre_add_hook( sub { $self->check_for_data(); }, 'persistent' );
+    return $self;
 }
-
 
 sub login {
-	my ($self) = @_;
-	
-	$self->debug( "Connecting to squeezecenter ..." ); 
+    my ($self) = @_;
+
+    $self->debug("Connecting to squeezecenter ...");
     $self->{squeezecenter}->start();
     $self->{squeezecenter}->set_echo(0);
-    
-    if ($self->{login} ne " ") {
-    	$self->{squeezecenter}->set('login ' . $self->{login});
+
+    if ( $self->{login} ne " " ) {
+        $self->{squeezecenter}->set( 'login ' . $self->{login} );
     }
-    	 
-    $self->{squeezecenter}->set('listen 1');      
+
+    $self->{squeezecenter}->set('listen 1');
 }
 
-sub reconnect {     
-	my ($self) = @_;
-	
-	$self->{squeezecenter}->stop();
+sub reconnect {
+    my ($self) = @_;
+
+    $self->{squeezecenter}->stop();
     $self->login();
 
 }
 
 sub reconnect_delay {
-    my ($self, $seconds) = @_;
-    my $action = sub {$self->reconnect()};
-    if (!$seconds) {
+    my ( $self, $seconds ) = @_;
+    my $action = sub { $self->reconnect() };
+    if ( !$seconds ) {
         $seconds = 60;
-        $self->debug("Connection to squeezecenter lost, will try to connect again in 1 minute.");
+        $self->debug(
+            "Connection to squeezecenter lost, will try to connect again in 1 minute."
+        );
     }
-    $$self{reconnect_timer}->set($seconds,$action);
+    $$self{reconnect_timer}->set( $seconds, $action );
 }
 
 sub check_for_data {
-	my ($self) = @_;
+    my ($self) = @_;
 
-	unless ($$self{squeezecenter}->connected()) {
-		$self->reconnect_delay();
-		return;
-	}
-			
-	if (my $data = $self->{squeezecenter}->said()) {
-	
-		# If we get a status response, check if we need to add the player to the lookup hash.
-		# This code will be executed after the status is requested in the 'add_player' routine.
-		# This is the only time we touch the actual server response, all other protocol specific 
-		# code is implemented in SqueezeboxCLI_Player.
-		if ($data =~ /([\w|%]{27})\s+status\s+player_name%3A(\w+)/) {
-			my $player_mac  = $1;
-			my $player_name = $2;
-			if (!defined($$self{players_mac}{$player_mac})) {
-				$self->debug("Adding $player_name to the MAC lookup", 2);
-				$$self{players_mac}{$player_mac} = $$self{players}{$player_name};
-				return;
-			}
-		
-		}
-		
-		if ($data =~ /([\w|%]{27})\s+(.+)/) {
-			$self->debug("Passing message to player '$1' for further processing", 4);
-			# Pass the message to the correct object for processing
-			$$self{players_mac}{$1}->process_cli_response($2);
-		} else {
-			$self->debug("Received unknown text: $data");
-		}
-		
-    	# if ($data =~ m/.* power 0 .*$/) {
-#         	main::print_log " power aus";        
+    unless ( $$self{squeezecenter}->connected() ) {
+        $self->reconnect_delay();
+        return;
+    }
+
+    if ( my $data = $self->{squeezecenter}->said() ) {
+
+# If we get a status response, check if we need to add the player to the lookup hash.
+# This code will be executed after the status is requested in the 'add_player' routine.
+# This is the only time we touch the actual server response, all other protocol specific
+# code is implemented in SqueezeboxCLI_Player.
+        if ( $data =~ /([\w|%]{27})\s+status\s+player_name%3A(\w+)/ ) {
+            my $player_mac  = $1;
+            my $player_name = $2;
+            if ( !defined( $$self{players_mac}{$player_mac} ) ) {
+                $self->debug( "Adding $player_name to the MAC lookup", 2 );
+                $$self{players_mac}{$player_mac}
+                    = $$self{players}{$player_name};
+                return;
+            }
+
+        }
+
+        if ( $data =~ /([\w|%]{27})\s+(.+)/ ) {
+            $self->debug(
+                "Passing message to player '$1' for further processing", 4 );
+
+            # Pass the message to the correct object for processing
+            $$self{players_mac}{$1}->process_cli_response($2);
+        }
+        else {
+            $self->debug("Received unknown text: $data");
+        }
+
+# if ($data =~ m/.* power 0 .*$/) {
+#         	main::print_log " power aus";
 #     	} elsif ($data =~ m/.* power 1 .*$/) {
-#         	main::print_log " power an";        
+#         	main::print_log " power an";
 #         #set $EG_WZ_Multimedia ON;
 #     	} elsif ($data =~ /([\w|%]+)\s+status\s+player_name%3A(\w+)/) {
 #     		$self->debug("Got status response for $1 (= $2), adding it to the lookup hash", 1);
-#     		
+#
 #     		$$self{players_mac}{$1} = shift(@{$self->{players}});
 #     	} else {
 #         	main::print_log " unknown text: $data";
 #     	}
-	}
+    }
 }
 
 sub add_player {
-	my ($self, $player) = @_;
-	
-	# Add the player to the list of players the gateway knows
-	$$self{players}{$player->{sb_name}} =  $player;
-	$self->debug( "Added player '" . $player->{sb_name} . "'");
-	
-	# Determine the MAC address of the player by requesting the status
-	$$self{squeezecenter}->set($player->{sb_name} . " status");
+    my ( $self, $player ) = @_;
+
+    # Add the player to the list of players the gateway knows
+    $$self{players}{ $player->{sb_name} } = $player;
+    $self->debug( "Added player '" . $player->{sb_name} . "'" );
+
+    # Determine the MAC address of the player by requesting the status
+    $$self{squeezecenter}->set( $player->{sb_name} . " status" );
 }
-	
-	
+
 package SqueezeboxCLI_Player;
 
 use strict;
@@ -172,27 +181,26 @@ use strict;
 
 use URI::Escape;
 
-@SqueezeboxCLI_Player::ISA = ('Generic_Item', "SqueezeboxCLI");
+@SqueezeboxCLI_Player::ISA = ( 'Generic_Item', "SqueezeboxCLI" );
 
 sub new {
-	my ($class, $name, $interface) = @_;
-	my $self = new Generic_Item();
-	bless $self, $class;
-	$$self{sb_name} = $name;
-	$$self{interface} = $interface;
-	$$self{interface}->add_player($self);
-	return $self;
+    my ( $class, $name, $interface ) = @_;
+    my $self = new Generic_Item();
+    bless $self, $class;
+    $$self{sb_name}   = $name;
+    $$self{interface} = $interface;
+    $$self{interface}->add_player($self);
+    return $self;
 }
 
 sub process_cli_response {
-	my ($self, $response) = @_;
-	$self->debug($self->get_object_name() . ": processing $response", 2);
-	
-	if ($response =~ /^power (\d)/) {
-		$self->debug($$self{object_name} . " power is " . $1);
-	}
-}
+    my ( $self, $response ) = @_;
+    $self->debug( $self->get_object_name() . ": processing $response", 2 );
 
+    if ( $response =~ /^power (\d)/ ) {
+        $self->debug( $$self{object_name} . " power is " . $1 );
+    }
+}
 
 =item C<set_receive()>
 
@@ -201,8 +209,8 @@ Handles setting the state of the object inside MisterHouse
 =cut
 
 sub set_receive {
-    my ($self, $p_state, $p_setby, $p_response) = @_;
-    $self->SUPER::set($p_state, $p_setby, $p_response);
+    my ( $self, $p_state, $p_setby, $p_response ) = @_;
+    $self->SUPER::set( $p_state, $p_setby, $p_response );
 }
 
 1;

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -408,7 +408,7 @@ sub play_notification {
     $self->send_cmd("time ?");
 
     # Save the current playlist
-    $self->send_cmd("playlist save prenotification_playlist_" . $self{object_name});
+    $self->send_cmd("playlist save prenotification_playlist_" . $$self{object_name});
 
     # Set the repeat to none
     $self->send_cmd("playlist repeat 0");

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -39,6 +39,7 @@ To play a file or URL from your user code you can use this function call:
 
 $sb_kitchen->play_notification('/Volumes/Media/speech/test1.wave');
 
+For additional debugging, add the option squeezeboxcli:3 to the 'debug' entry to your mh.ini.private file.
 
 =head2 OVERVIEW
 
@@ -273,8 +274,8 @@ sub process_cli_response {
                     . $self->state() );
         }
     }
-    if ( ( $response =~ /^pause 0/ ) ) {
-
+    if ( ( $response =~ /pause 0/ ) ) {
+		# Removed the /^ requirement because the classic player reports 'playlist pause 0' instead of 'pause 0' like the radio does
         # Request the current mode if pause is 0
         $self->send_cmd("mode ?");
     }

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -1,0 +1,208 @@
+=head1 B<SqueezeboxCLI>
+
+=head2 SYNOPSIS
+
+The module enables control of a Squeezebox device through the CLI (command line 
+interface) of the Squeezebox server (a.k.a. Logitech Media server).
+
+=head2 CONFIGURATION
+
+This module connects to the Squeezebox server through the telnet interface. The following 
+preparations need to be done to get the code up and running:
+
+Create the Squeezebox devices in the mht file or in user code:
+
+.mht file:
+
+  CODE, require SqueezeboxCLI; #noloop 
+  CODE, $sb_living  = new SqueezeboxCLI('living', <server_name>); #noloop
+  CODE, $sb_kitchen = new SqueezeboxCLI('kitchen', <servername>); #noloop
+
+=head2 OVERVIEW
+
+This module allows control over a player through the telnet command line interface of
+the server.
+
+=cut
+package SqueezeboxCLI;
+
+# Used solely to provide a consistent logging feature, copied from Nest.pm
+
+use strict;
+
+#log levels
+my $warn  = 1;
+my $info  = 2;
+my $trace = 3;
+
+sub debug {
+    my ($self, $message, $level) = @_;
+    $level = 0 if $level eq '';
+    my $line = '';
+    my @caller = caller(0);
+    if ($::Debug{'squeezeboxcli'} >= $level || $level == 0){
+        $line = " at line " . $caller[2] if $::Debug{'squeezeboxcli'} >= $trace;
+        ::print_log("[" . $caller[0] . "] " . $message . $line);
+    }
+}
+
+package SqueezeboxCLI_Interface;
+
+use strict;
+
+@SqueezeboxCLI_Interface::ISA = ('Generic_Item', 'SqueezeboxCLI');
+
+sub new {
+	my ($class, $server, $port, $user, $pass) = @_;
+	my $self = new Generic_Item();
+	bless $self, $class;
+	$$self{server} = $server;
+	$$self{port}   = $port || 9090;
+	$$self{login}  = $user . " " . $pass || "";
+	$$self{players} = {};
+	$$self{reconnect_timer} = new Timer;
+	$$self{squeezecenter} = new Socket_Item(undef, undef, $$self{server}. ":" . $$self{port}, "squeezecenter_cli", 'tcp', 'record');
+	$self->login();
+	::MainLoop_pre_add_hook(sub {$self->check_for_data();}, 'persistent');
+	return $self;
+}
+
+
+sub login {
+	my ($self) = @_;
+	
+	$self->debug( "Connecting to squeezecenter ..." ); 
+    $self->{squeezecenter}->start();
+    $self->{squeezecenter}->set_echo(0);
+    
+    if ($self->{login} ne " ") {
+    	$self->{squeezecenter}->set('login ' . $self->{login});
+    }
+    	 
+    $self->{squeezecenter}->set('listen 1');      
+}
+
+sub reconnect {     
+	my ($self) = @_;
+	
+	$self->{squeezecenter}->stop();
+    $self->login();
+
+}
+
+sub reconnect_delay {
+    my ($self, $seconds) = @_;
+    my $action = sub {$self->reconnect()};
+    if (!$seconds) {
+        $seconds = 60;
+        $self->debug("Connection to squeezecenter lost, will try to connect again in 1 minute.");
+    }
+    $$self{reconnect_timer}->set($seconds,$action);
+}
+
+sub check_for_data {
+	my ($self) = @_;
+
+	unless ($$self{squeezecenter}->connected()) {
+		$self->reconnect_delay();
+		return;
+	}
+			
+	if (my $data = $self->{squeezecenter}->said()) {
+	
+		# If we get a status response, check if we need to add the player to the lookup hash.
+		# This code will be executed after the status is requested in the 'add_player' routine.
+		# This is the only time we touch the actual server response, all other protocol specific 
+		# code is implemented in SqueezeboxCLI_Player.
+		if ($data =~ /([\w|%]{27})\s+status\s+player_name%3A(\w+)/) {
+			my $player_mac  = $1;
+			my $player_name = $2;
+			if (!defined($$self{players_mac}{$player_mac})) {
+				$self->debug("Adding $player_name to the MAC lookup", 2);
+				$$self{players_mac}{$player_mac} = $$self{players}{$player_name};
+				return;
+			}
+		
+		}
+		
+		if ($data =~ /([\w|%]{27})\s+(.+)/) {
+			$self->debug("Passing message to player '$1' for further processing", 4);
+			# Pass the message to the correct object for processing
+			$$self{players_mac}{$1}->process_cli_response($2);
+		} else {
+			$self->debug("Received unknown text: $data");
+		}
+		
+    	# if ($data =~ m/.* power 0 .*$/) {
+#         	main::print_log " power aus";        
+#     	} elsif ($data =~ m/.* power 1 .*$/) {
+#         	main::print_log " power an";        
+#         #set $EG_WZ_Multimedia ON;
+#     	} elsif ($data =~ /([\w|%]+)\s+status\s+player_name%3A(\w+)/) {
+#     		$self->debug("Got status response for $1 (= $2), adding it to the lookup hash", 1);
+#     		
+#     		$$self{players_mac}{$1} = shift(@{$self->{players}});
+#     	} else {
+#         	main::print_log " unknown text: $data";
+#     	}
+	}
+}
+
+sub add_player {
+	my ($self, $player) = @_;
+	
+	# Add the player to the list of players the gateway knows
+	$$self{players}{$player->{sb_name}} =  $player;
+	$self->debug( "Added player '" . $player->{sb_name} . "'");
+	
+	# Determine the MAC address of the player by requesting the status
+	$$self{squeezecenter}->set($player->{sb_name} . " status");
+}
+	
+	
+package SqueezeboxCLI_Player;
+
+use strict;
+
+=head2 DEPENDENCIES
+
+  URI::Escape       - The CLI interface uses an escaped format
+
+=cut
+
+use URI::Escape;
+
+@SqueezeboxCLI_Player::ISA = ('Generic_Item', "SqueezeboxCLI");
+
+sub new {
+	my ($class, $name, $interface) = @_;
+	my $self = new Generic_Item();
+	bless $self, $class;
+	$$self{sb_name} = $name;
+	$$self{interface} = $interface;
+	$$self{interface}->add_player($self);
+	return $self;
+}
+
+sub process_cli_response {
+	my ($self, $response) = @_;
+	$self->debug($self->get_object_name() . ": processing $response", 2);
+	
+	if ($response =~ /^power (\d)/) {
+		$self->debug($$self{object_name} . " power is " . $1);
+	}
+}
+
+
+=item C<set_receive()>
+
+Handles setting the state of the object inside MisterHouse
+
+=cut
+
+sub set_receive {
+    my ($self, $p_state, $p_setby, $p_response) = @_;
+    $self->SUPER::set($p_state, $p_setby, $p_response);
+}
+
+1;

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -190,6 +190,8 @@ sub new {
     $$self{sb_name}   = $name;
     $$self{interface} = $interface;
     $$self{interface}->add_player($self);
+    # Ensure we can turn the SB on and off
+	$self->addStates ('on', 'off');
     return $self;
 }
 
@@ -199,6 +201,7 @@ sub process_cli_response {
 
     if ( $response =~ /^power (\d)/ ) {
         $self->debug( $$self{object_name} . " power is " . $1 );
+        
     }
 }
 
@@ -208,9 +211,44 @@ Handles setting the state of the object inside MisterHouse
 
 =cut
 
-sub set_receive {
-    my ( $self, $p_state, $p_setby, $p_response ) = @_;
-    $self->SUPER::set( $p_state, $p_setby, $p_response );
+#sub set_receive {
+#    my ( $self, $p_state, $p_setby, $p_response ) = @_;
+#    $self->SUPER::set( $p_state, $p_setby, $p_response );
+#    $self->debug( $$self{object_name} . " setting from MH state to " . $p_state . " by " . $p_setby);
+#    print 'Test';
+#}
+
+=item C<default_setstate()>
+
+Handle state changes of the Squeezeboxes
+
+=cut
+
+sub default_setstate
+{
+    my ($self, $state, $substate, $set_by) = @_;
+    	
+    my $cmnd = ($state =~ /^off/i) ? 'stop' : 'play';
+    	
+    return -1 if ($self->state eq $state); # Don't propagate state unless it has changed.
+    $self->debug("[SqueezeboxCLI] Request " . $self->get_object_name . " turn " . $cmnd );
+        
+	if ($cmnd eq 'stop') {
+    	$$self{interface}{squeezecenter}->set($$self{sb_name} . ' power 0');
+	} else {	
+	    $$self{interface}{squeezecenter}->set($$self{sb_name} . ' power 1');
+    }
+	
 }
 
+=item C<addStates()>
+
+Add states to the device
+
+=cut
+
+sub addStates {
+    my $self = shift;
+    push(@{$$self{states}}, @_) unless $self->{displayonly};
+}
 1;

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -19,8 +19,8 @@ Note: [parameters] are optional.
 
   CODE, require SqueezeboxCLI; #noloop 
   CODE, $squeezecenter = new SqueezeboxCLI_Interface('hostname'); #noloop 
-  CODE, $sb_living  = new SqueezeboxCLI('living', $squeezecenter, [coupled_device], [auto_off_time]); #noloop
-  CODE, $sb_kitchen = new SqueezeboxCLI('kitchen', $squeezecenter, [coupled_device], [auto_off_time]); #noloop
+  CODE, $sb_living  = new SqueezeboxCLI_Player('living', $squeezecenter, [coupled_device], [auto_off_time]); #noloop
+  CODE, $sb_kitchen = new SqueezeboxCLI_Player('kitchen', $squeezecenter, [coupled_device], [auto_off_time]); #noloop
   
 Optional parameters:
 
@@ -158,7 +158,11 @@ sub check_for_data {
                 "Passing message to player '$1' for further processing", 4 );
 
             # Pass the message to the correct object for processing
-            $$self{players_mac}{$1}->process_cli_response($2);
+            # but only do this for players we're supposed to manage
+            my $player = $1;
+            if (defined $$self{players_mac}{$player}) {
+            	$$self{players_mac}{$player}->process_cli_response($2);
+            }
         }
         else {
             $self->debug("Received unknown text: $data");

--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -288,7 +288,7 @@ sub process_cli_response {
         $$self{mixer_volume} = $1;
         $self->debug( $$self{object_name} . " mixer volume is " . $1 );
     }
-    if ( ( $response =~ /^pause 1/ || $response =~ /mode[:| ][pause|stop]/ )
+    if ( ( $response =~ /^pause 1/ || $response =~ /mode[:| ][pause|stop]/ || $response =~ /playlist stop/ )
         && $self->state() ne 'off' )
     {
         $self->debug( $$self{object_name}

--- a/lib/xPL_Squeezebox.pm
+++ b/lib/xPL_Squeezebox.pm
@@ -212,4 +212,6 @@ Lieven Hollevoet  lieven@lika.be
   Gregg Liming for the idea that we should not rely on the heartbeat messages to get the 
      status of the Squeezebox.
 
+=cut
+
 1;

--- a/lib/xPL_Squeezebox.pm
+++ b/lib/xPL_Squeezebox.pm
@@ -1,19 +1,15 @@
-=begin comment
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+=head1 B<xPL_Squeezebox>
+
+=head2 DESCRIPTION
 
 xPL_Squeezebox.pm - xPL support for the former SlimDevices (now Logitech) Squeezebox devices
 
-  $Date$
-  $Revision$
+This module allows to easily integrate Squeezebox devices in your MH setup by using the xPL
+interface to the devices.
 
-Info:
+It supports device monitoring (check the heartbeat), keeps the state of the 
+squeezebox (playing/stopped/power_off), and allows to play a file/URL.
 
-  This module allows to easily integrate Squeezebox devices in your MH setup.
-
-  It supports device monitoring (check the heartbeat), keeps the state of the 
-  squeezebox (playing/stopped/power_off), allows to play sounds while 
-  maintaining the current playlist.
-     
 Usage:
 
  In your items.mht, add the squeezebox devices like this:
@@ -39,31 +35,18 @@ Usage:
 	set $sb_status_req_timer 60;
 	xPL_Squeezebox::request_all_stat();
    }
-   
- Turn on debug=xpl_squeezebox for diagnostic messages
- 
+
+Turn on debug=xpl_squeezebox for diagnostic messages
+
 Currently supports:
   * Turning the SB on/off (play/stop command)
   * Keeping track of the status of the SB when it is controlled by the remote/web interface
+  * Playing a file or an URL on a Squeezebox
 
-Todo:
-  * Add code to control the amplifier based on the state of the SB
-  * Add code to pause the current playlist, play a certain file, and resume so that we can use the 
-     SB to notify incoming calls/doorbell/...
-  * Support displaying messages on the SB screen
-  * Add internal status request timer
-  
-License:
-  This free software is licensed under the terms of the GNU public license.
+=head2 METHODS
 
-Authors:
-  Lieven Hollevoet  lieven@lika.be
+=over
 
-Credits:
-  Gregg Liming for the idea that we should not rely on the heartbeat messages to get the 
-     status of the Squeezebox.
-
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 =cut
 
 use strict;
@@ -72,6 +55,12 @@ package xPL_Squeezebox;
 use base qw(xPL_Item);
 
 our @device_list;
+
+=item C<new()>
+
+Creates a new object
+
+=cut
 
 sub new {
     my ($class, $p_source) = @_;
@@ -91,35 +80,63 @@ sub new {
     return $self;
 }
 
-	
-# Craft a message to request the state of all squeezeboxen
-# We need to do this through this rather ugly code that keeps a list of all objects that have been created
-# and that goes over this list one by one.
-# This is because SqueezeCenter currently does not respond to an audio.request that is directed to
-# slimdev-slimserv.*
-# If it would we could here simply use 
-#   	&xPL::sendXpl('slimdev-slimserv.*', 'cmnd', 'audio.request' => { 'cmd' => 'status' });
+=item C<request_all_stat()>
+
+Requests the state of all squeezebox devices
+
+We need to do this through this rather elaborate code that keeps a list of all objects 
+that have been created and that goes over this list one by one.
+This is because SqueezeCenter currently does not respond to an audio.request that is directed to
+slimdev-slimserv.*
+If it would we could here simply use 
+&xPL::sendXpl('slimdev-slimserv.*', 'cmnd', 'audio.request' => { 'cmd' => 'status' });
+
+=cut
+
 sub request_all_stat {
 	foreach (@device_list) {
-		$_->SUPER::send_cmnd('audio.request' => { 'cmd' => 'status' });
+		$_->request_stat();
 	}
 }
 
-# Request the status of the device
+=item C<request_stat()>
+
+Request the status of a single Squeezebox
+
+=cut
+
 sub request_stat {
     my ($self) = @_;
     $self->SUPER::send_cmnd('audio.request' => { 'cmd' => 'status' });
 }
+
+=item C<id()>
+
+Returns the ID of the Squeezebox
+
+=cut
 
 sub id {
     my ($self) = @_;
     return $$self{id};
 }
 
+=item C<addStates()>
+
+Add states to the device
+
+=cut
+
 sub addStates {
     my $self = shift;
     push(@{$$self{states}}, @_) unless $self->{displayonly};
 }
+
+=item C<ignore_message()>
+
+Determine what xPL messages will be interpreted
+
+=cut
 
 sub ignore_message {
     my ($self, $p_data) = @_;
@@ -130,6 +147,12 @@ sub ignore_message {
     return $ignore_msg;
 }
 
+=item C<default_setstate()>
+
+Handle state changes of the Squeezeboxes
+
+=cut
+
 sub default_setstate
 {
     my ($self, $state, $substate, $set_by) = @_;
@@ -139,7 +162,7 @@ sub default_setstate
                 . " state is $state") if $main::Debug{xpl_squeezebox};
            # TO-DO: process all of the other pertinent attributes available
     	   return -1 if $self->state eq $state; # don't propagate state unless it has changed
-	}
+		}
     } else {
     	my $cmnd = ($state =~ /^off/i) ? 'stop' : 'play';
     	
@@ -158,5 +181,35 @@ sub default_setstate
     }
 	
 }
-    
+
+=item C<play(file/URL)>
+
+Accepts a file (a full paths on the machine that is running the Squeezebox server 
+application) or an URL that should be played on the device.
+
+=cut
+
+sub play
+{
+	my ($self, $file, $source) = @_;
+	
+	$self->SUPER::send_cmnd('audio.slimserv' => {'command' => $file} );
+	
+	return;
+}
+
+=back 
+
+=head2 LICENSE
+
+This free software is licensed under the terms of the GNU public license.
+
+=head2 AUTHOR
+
+Lieven Hollevoet  lieven@lika.be
+
+=head2 CREDITS
+  Gregg Liming for the idea that we should not rely on the heartbeat messages to get the 
+     status of the Squeezebox.
+
 1;


### PR DESCRIPTION
This code started out as an attempt to enable Squeezeboxes to play notifications, but ended up to be a replacement of the Squeezebox xPL module. I'm using this module in production now instead of that xPL module that has been running fine for many years.

The CLI interface allows us to do more than what we can do through the xPL interface, and it removed the requirement to poll the status of the various players regularly.