### PR TITLE
Add strawberry perl support

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -159,6 +159,25 @@ sub RRDs::error;
 sub ReadMode {};                # In case Readkey is not installed
 sub ReadKey  {};
 
+#Provide a BuildNumber function with output similar to the 
+#ActiveState Perl Win32::BuildNumber for running on other
+#Windows Perl ports (e.g. Strawberry perl)
+sub buildNumber {
+	if( defined &Win32::BuildNumber) {
+		return &Win32::BuildNumber;
+	} elsif( defined $^V) {
+		my ($major,$minor, $patch) = split('\.',sprintf( "%vd", $^V));
+		$patch = sprintf("%02d",$patch);
+		return ($minor.$patch)*1;
+	} else {
+		my ($major,$minor_patch) = split('\.',$]);
+		my ($minor, $patch) = ($minor_patch =~ /(.{1,3})/g);
+		$minor = sprintf("%02d",$minor);
+		$patch = sprintf("%02d",$patch);
+		return( ($minor.$patch)*1);
+	}
+}
+
 BEGIN {
     &setup_INC;
     &check_for_run_cmd;
@@ -180,7 +199,7 @@ BEGIN {
 #       push (@INC, './../lib', './../lib/site', '.');
 #       push (@INC, './../lib');
         if ($^O eq 'MSWin32') {
-            my $build = &Win32::BuildNumber;
+            my $build = buildNumber();
             if ($build < 600) {
                 push @INC, "${Pgm_Path}/../lib/site_win50";
             }
@@ -274,7 +293,7 @@ BEGIN {
         print "Pgm  version: $Version  \nLast updated: $Version_date\n";
         $Info{Perl_version} = $];
                                 # Use eval to avoid problems with earlier version (e.g. build 502)
-        $Info{Perl_version} .= " Build " . eval "&Win32::BuildNumber()" if $OS_win;
+        $Info{Perl_version} .= " Build " . buildNumber() if $OS_win;
         print "Perl version: $Info{Perl_version}\n";
         print "OS   version: $^O $Info{OS_name} $Info{OS_version} $Info{OS_filesystem}\n";
         print "Other       : user=$Info{User} pid=$$ box=$Info{Machine} cpu=$ENV{PROCESSOR_ARCHITECTURE}-$ENV{PROCESSOR_LEVEL}\n";
@@ -487,7 +506,7 @@ EOF
                                 #  - For some reason, perl2exe binary abends here, so we evaled it earlier
             eval "use Win32::Setupsup qw(WaitForAnyWindow SendKeys EnumChildWindows SetFocus SetWindowText GetWindowText)"
                 unless $Info{Perl_compiled};
-            print "\nError in loading module=Win32::Setupsup:\n  $@\n" if $@; #  and &Win32::BuildNumber < 580;
+            print "\nError in loading module=Win32::Setupsup:\n  $@\n" if $@;
 
             eval "use Win32::Sound";
             print "\nError in loading module=Win32::Sound:\n  $@\n" if $@;

--- a/bin/print_socket_fork_memmap.pl
+++ b/bin/print_socket_fork_memmap.pl
@@ -11,21 +11,44 @@
 # string in via a memory map, rather than a slow external file read and write.
 
 my ($Pgm_Path, $Pgm_Name);
+
+#Provide a BuildNumber function with output similar to the 
+#ActiveState Perl Win32::BuildNumber for running on other
+#Windows Perl ports (e.g. Strawberry perl)
+sub buildNumber {
+	if( defined &Win32::BuildNumber) {
+		return &Win32::BuildNumber;
+	} elsif( defined $^V) {
+		my ($major,$minor, $patch) = split('\.',sprintf( "%vd", $^V));
+		$patch = sprintf("%02d",$patch);
+		return ($minor.$patch)*1;
+	} else {
+		my ($major,$minor_patch) = split('\.',$]);
+		my ($minor, $patch) = ($minor_patch =~ /(.{1,3})/g);
+		$minor = sprintf("%02d",$minor);
+		$patch = sprintf("%02d",$patch);
+		return( ($minor.$patch)*1);
+	}
+}
+
 BEGIN {
     ($Pgm_Path, $Pgm_Name) = $0 =~ /(.*)[\\\/](.*)\.?/; 
     $Pgm_Path = '.' unless $Pgm_Path; 
 
 		 # Need to set up INC so we can find the MemMap module
-    my $build = &Win32::BuildNumber;
+    my $build = buildNumber();
     if ($build < 600) {
-	push @INC, './../lib/site_win50';
+		push @INC, './../lib/site_win50';
     }
     elsif ($build < 800) {
-	push @INC, './../lib/site_win56';
+		push @INC, './../lib/site_win56';
     }
-    else {
-	push @INC, './../lib/site_win58';
+    elsif ($build < 900) {
+		push @INC, './../lib/site_win58';
     }
+	elsif ($build < 1300 and $build > 1199) {
+		push @INC, "./../lib/site_win512";
+	}
     push @INC, './../lib/site';
     push @INC, './../lib';
 }

--- a/lib/Process_Item.pm
+++ b/lib/Process_Item.pm
@@ -190,9 +190,8 @@ sub start_next {
     my ($cmd_path, $cmd_args);
 
     if ($type eq 'eval') {
-        if ($main::OS_win and ($ENV{sourceExe} or &Win32::BuildNumber() < 600)) {
-            my $msg = "Sorry, {Process_Item eval fork only supported with windows perl build 5.6 or later.\n   cmd=$cmd";
-            print "$msg\n";
+        if ($main::OS_win ) {
+            my $msg = "Sorry, Process_Item eval fork only supported with linux.\n   cmd=$cmd";
             &main::print_log($msg);
             return;
         }


### PR DESCRIPTION
mh included a call to an ActiveState perl specific function for
determining the perl version.  Modified to try the original method
then $^V then ^] to get the perl version.  The result is formatted
like the original ActiveState function (i.e. no major number, two
digits for minor version, and two digits for patch version.