### PR TITLE
Fixes for web floorplan view

### DIFF
--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -901,7 +901,7 @@ TODO
 
 sub get_fp_location {
     my ($self) = @_;
-    if (! @{$$self{location}} ) { return }
+    if (! defined @{$$self{location}} ) { return }
     return @{$$self{location}};
 }
 

--- a/web/bin/floorplan.pl
+++ b/web/bin/floorplan.pl
@@ -169,13 +169,14 @@ sub web_fp_item #render all items based on type
 		 $p_obj->isa('Weeder_Light')   or
 		 $p_obj->isa('UPB_Device')     or
 		 $p_obj->isa('Insteon_Device') or
+		 $p_obj->isa('Insteon::DeviceController') or
+		 $p_obj->isa('Insteon::BaseLight') or
 		 $p_obj->isa('UPB_Link')       or
 		 $p_obj->isa('EIB_Item')       or
 		 $p_obj->isa('EIB1GItem')      or
 		 $p_obj->isa('EIB2_Item')      or
 		 $p_obj->isa('EIO_Item')       or
 		 $p_obj->isa('UIO_Item')       or
-		 $p_obj->isa('Generic_Item')   or
 		 $p_obj->isa('X10_Item')
 		 ) {
 		if ($p_obj->state eq 'off') {
@@ -252,6 +253,14 @@ sub web_fp_item #render all items based on type
 	} elsif ($p_obj->isa('iButton')) {
 		$l_text=web_fp_filter_name($p_obj->{object_name});
 		$l_text.=':' . $p_obj->read_temp();
+	} elsif ($p_obj->isa('Generic_Item') ) {
+		if ($p_obj->state eq 'off') {
+			$l_image='fp-light-off.gif';
+			$l_state='on';
+		} else {
+			$l_image='fp-light-on.gif';
+			$l_state='off';
+		}
 	} else { #Unknown object
 		$l_text=web_fp_filter_name($p_obj->{object_name});
 		$l_text.=':' . $p_obj->state();


### PR DESCRIPTION
Generic_Item.pm was changed recently and broke the floorplan web view so I finally fixed that. Plus I have had other local changes to fix the icons for Presence/Light_Item objects. This adds both those changes. This one is slightly different then v1 I pushed yesterday because I added back Generic_Item support I just added it at the very end. Is a bit odd because a Generic Item shows up as a light bulb but don't really have a better icon currently available
![screenshot from 2014-12-13 13 06 45](https://cloud.githubusercontent.com/assets/10178869/5464255/7884c7ac-854b-11e4-9e6a-b5725b373823.png)
