### PR TITLE
Show which dtr_active command failed if it happens.

### DIFF
--- a/bin/test_x10
+++ b/bin/test_x10
@@ -73,7 +73,7 @@ $device->databits(8);
 $device->baudrate(4800);
 $device->parity("none");
 $device->stopbits(1);
-$device->dtr_active(1);
+$device->dtr_active(1) or warn "Could not set dtr_active(1)";
 $device->handshake("none");
 $device->write_settings || die "Could not set up port\n";
 

--- a/lib/AD2.pm
+++ b/lib/AD2.pm
@@ -319,7 +319,7 @@ sub init {
    $serial_port->stopbits(1);
    $serial_port->handshake('none');
    $serial_port->datatype('raw');
-   $serial_port->dtr_active(1);
+   $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
    $serial_port->rts_active(0);
 
    select( undef, undef, undef, .100 );    # Sleep a bit

--- a/lib/Compool.pm
+++ b/lib/Compool.pm
@@ -87,7 +87,7 @@ sub init
 
     $serial_port->is_handshake("none");         #&? Should this be DTR?
 
-    $serial_port->dtr_active(1);		
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";		
     $serial_port->rts_active(0);		
     select (undef, undef, undef, .100); 	# Sleep a bit
     ::print_log "Compool init\n" if $main::Debug{compool};
@@ -647,7 +647,7 @@ sub send_command
     # The API resets errors when reading status, $LatchErrorFlags
     # is all $ErrorFlags since they were last explicitly cleared
 
-    #$serial_port->dtr_active(1);
+    #$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
     $serial_port->rts_active(1);
 #   select (undef, undef, undef, .05); # Sleep a bit
     select (undef, undef, undef, .04); # Sleep a bit
@@ -655,7 +655,7 @@ sub send_command
     {
  #      select (undef, undef, undef, .02); # Sleep a bit
         select (undef, undef, undef, .025); # Sleep a bit
-        #$serial_port->dtr_active(1);
+        #$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
         $serial_port->rts_active(0);
         print "Compool send command ok\n" if $main::Debug{compool} and $main::Debug{compool} >= 3;
 
@@ -668,7 +668,7 @@ sub send_command
     {
 #       select (undef, undef, undef, .02); # Sleep a bit
         select (undef, undef, undef, .05); # Sleep a bit
-        #$serial_port->dtr_active(1);
+        #$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
         $serial_port->rts_active(0);
         print "Compool send command failed sent " . $temp. " bytes\n";
         return -1;

--- a/lib/Concept.pm
+++ b/lib/Concept.pm
@@ -81,7 +81,7 @@ sub init
     $serial_port->parity("none");
     $serial_port->stopbits(1);
 
-    $serial_port->dtr_active(1);		
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";		
     $serial_port->rts_active(1);		
     select (undef, undef, undef, .100); 	# Sleep a bit
 }

--- a/lib/DSC5401.pm
+++ b/lib/DSC5401.pm
@@ -106,7 +106,7 @@ sub init {
    $serial_port->stopbits(1);
    $serial_port->handshake('none');
    $serial_port->datatype('raw');
-   $serial_port->dtr_active(1);
+   $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
    $serial_port->rts_active(0);
 
    #$serial_port->debug(0);

--- a/lib/DSC_Alarm.pm
+++ b/lib/DSC_Alarm.pm
@@ -117,7 +117,7 @@ sub init
     $serial_port->parity("none");
     $serial_port->stopbits(1);
 
-    $serial_port->dtr_active(1);
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
     $serial_port->rts_active(0);
     select (undef, undef, undef, .100); 	# Sleep a bit
 }

--- a/lib/FroggyRita.pm
+++ b/lib/FroggyRita.pm
@@ -394,7 +394,7 @@ sub init {
    $serial_port->stopbits(2);
    $serial_port->handshake('none');
    $serial_port->datatype('raw');
-   $serial_port->dtr_active(0);
+   $serial_port->dtr_active(0) or warn "Could not set dtr_active(0)";
    $serial_port->rts_active(1);
 }
 

--- a/lib/Insteon/PLMTerminal.pl
+++ b/lib/Insteon/PLMTerminal.pl
@@ -131,7 +131,7 @@ $device->databits(8);
 $device->baudrate(19200);
 $device->parity("none");
 $device->stopbits(1);
-$device->dtr_active(1);
+$device->dtr_active(1) or warn "Could not set dtr_active(1)";
 $device->handshake("none");
 $device->read_char_time(0);    # don't wait for each character
 $device->read_const_time(RX_BLOCKTIME); # wait RX_BLOCKTIME (ms) per unfulfilled "read" call

--- a/lib/Lynx10PLC.pm
+++ b/lib/Lynx10PLC.pm
@@ -230,7 +230,7 @@ sub serial_startup
 			$serial_port->databits(8);
 			$serial_port->parity("none");
 			$serial_port->stopbits(1);
-			$serial_port->dtr_active(1);
+			$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
 			$serial_port->rts_active(0);
 			$serial_port->write_settings;
 			select (undef, undef, undef, .100);		 # Sleep a bit

--- a/lib/Serial_Item.pm
+++ b/lib/Serial_Item.pm
@@ -109,7 +109,7 @@ sub set_dtr {
     my ($self, $state) = @_;
     my $port_name = $self->{port_name};
     if (my $serial_port = $main::Serial_Ports{$port_name}{object}) {
-        $main::Serial_Ports{$port_name}{object}->dtr_active($state);
+        $main::Serial_Ports{$port_name}{object}->dtr_active($state) or warn "Could not set dtr_active($state)";
         print "Serial_port $port_name dtr set to $state\n" if $main::Debug{serial};
     }
     else {

--- a/lib/Stargate485.pm
+++ b/lib/Stargate485.pm
@@ -67,7 +67,7 @@ sub init
 
     $serial_port->handshake("none");         #&? Should this be DTR?
 
-    $serial_port->dtr_active(1);		
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";		
     $serial_port->rts_active(0);		
     select (undef, undef, undef, .100); 	# Sleep a bit
     ::print_log "Stargate485 init\n" if $main::Debug{Stargate485};

--- a/lib/USB_UIRT.pm
+++ b/lib/USB_UIRT.pm
@@ -566,7 +566,7 @@ sub usb_uirt_send {
 	push @bytes, $checksum;
 	$hex .= sprintf '%02x', $checksum;
 	print "USB_UIRT sending $hex\n";
-	$main::Serial_Ports{USB_UIRT}{object}->dtr_active(0);
+	$main::Serial_Ports{USB_UIRT}{object}->dtr_active(0) or warn "Could not set dtr_active(0)";
 	$main::Serial_Ports{USB_UIRT}{object}->write(pack 'C*', @bytes);
 }
 

--- a/lib/X10_MR26.pm
+++ b/lib/X10_MR26.pm
@@ -58,7 +58,7 @@ sub check_for_data {
 
     # Sending commands to another device on the same serial port may have dropped
     # the DTR signal, so let the MR-26 know we're ready to recieve data again
-    $main::Serial_Ports{MR26}{object}->dtr_active(1);
+    $main::Serial_Ports{MR26}{object}->dtr_active(1) or warn "Could not set dtr_active(1)";
 
     &main::check_for_generic_serial_data('MR26');
     my $data = $main::Serial_Ports{MR26}{data_record};

--- a/lib/Xantech.pm
+++ b/lib/Xantech.pm
@@ -56,7 +56,7 @@ sub init
 
     #$serial_port->is_handshake("none");         #&? Should this be DTR?
 
-    $serial_port->dtr_active(1);		
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";		
     $serial_port->rts_active(0);		
     select (undef, undef, undef, .100); 	# Sleep a bit
     ::print_log "Xantech init\n" if $main::Debug{xantech};

--- a/lib/site/ControlX10/CM17.pm
+++ b/lib/site/ControlX10/CM17.pm
@@ -155,13 +155,13 @@ sub send_bits {
     my @bits = split //, $bits;
 
                                 # Reset the device
-    $serial_port->dtr_active(0);
+    $serial_port->dtr_active(0) or warn "Could not set dtr_active(0)";
     $serial_port->rts_active(0);
     select (undef, undef, undef, .100); # How long??
 
 
                                 # Turn the device on
-    $serial_port->dtr_active(1);
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
     $serial_port->rts_active(1);
     select (undef, undef, undef, .20);  # How long??
 
@@ -180,14 +180,14 @@ sub send_bits {
     }
                                 # Leave the device on till switch occurs ... emperically derived 
                                 #  - 50->70  ms seemed to be the minnimum
-    $serial_port->dtr_active(1);
+    $serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
     $serial_port->rts_active(1);
     select (undef, undef, undef, .150);
 
     print " done\n" if $DEBUG;
 
                                 # Turn the device off
-    $serial_port->dtr_active(0);
+    $serial_port->dtr_active(0) or warn "Could not set dtr_active(0)";
     $serial_port->rts_active(0);
 
 }

--- a/lib/site/Device/SerialPort.pm
+++ b/lib/site/Device/SerialPort.pm
@@ -2300,7 +2300,7 @@ Device::SerialPort - Linux/POSIX emulation of Win32::SerialPort functions.
   $PortObj->purge_tx;
 
       # controlling outputs from the port
-  $PortObj->dtr_active(T);		# sends outputs direct to hardware
+  $PortObj->dtr_active(T) or warn "Could not set dtr_active(T)";		# sends outputs direct to hardware
   $PortObj->rts_active(Yes);		# return status of ioctl call
 					# return undef on failure
 

--- a/lib/site/Win32API/CommPort.pm
+++ b/lib/site/Win32API/CommPort.pm
@@ -2580,7 +2580,7 @@ Additional useful constants may be exported eventually.
   $PortObj->purge_tx;
 
       # controlling outputs from the port
-  $PortObj->dtr_active(T);		# sends outputs direct to hardware
+  $PortObj->dtr_active(T) or warn "Could not set dtr_active(T)";		# sends outputs direct to hardware
   $PortObj->rts_active(Yes);		# returns status of API call
   $PortObj->break_active(N);		# NOT state of bit
 
@@ -2688,12 +2688,12 @@ when I<initialize> has completed successfully.
   $PortObj->is_stopbits(1);
   $PortObj->is_handshake("rts");
   $PortObj->is_buffers(4096, 4096);
-  $PortObj->dtr_active(T);
+  $PortObj->dtr_active(T) or warn "Could not set dtr_active(T)";
 
   @required = qw( BAUD DATA STOP PARITY );
   $PortObj->initialize(@required) || undef $PortObj;
 
-  $PortObj->dtr_active(f);
+  $PortObj->dtr_active(f) or warn "Could not set dtr_active(f)";
   $PortObj->is_baudrate(300);
 
   $PortObj->close || die;

--- a/lib/site/eg_cm11.plx
+++ b/lib/site/eg_cm11.plx
@@ -47,7 +47,7 @@ $serial_port->databits(8);
 $serial_port->baudrate(4800);
 $serial_port->parity("none");
 $serial_port->stopbits(1);
-$serial_port->dtr_active(1);
+$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
 $serial_port->handshake("none");
 $serial_port->write_settings || die "Could not set up port\n";
 

--- a/lib/site/eg_cm17.plx
+++ b/lib/site/eg_cm17.plx
@@ -45,7 +45,7 @@ $serial_port->databits(8);
 $serial_port->baudrate(4800);
 $serial_port->parity("none");
 $serial_port->stopbits(1);
-$serial_port->dtr_active(1);
+$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
 $serial_port->handshake("none");
 $serial_port->write_settings || die "Could not set up port\n";
 

--- a/lib/site/eg_ti103.plx
+++ b/lib/site/eg_ti103.plx
@@ -47,7 +47,7 @@ $serial_port->databits(8);
 $serial_port->baudrate(19200);
 $serial_port->parity("none");
 $serial_port->stopbits(1);
-$serial_port->dtr_active(1);
+$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
 $serial_port->handshake("none");
 $serial_port->write_settings || die "Could not set up port\n";
 

--- a/lib/site/send_ti103.pl
+++ b/lib/site/send_ti103.pl
@@ -48,7 +48,7 @@ $serial_port->databits(8);
 $serial_port->baudrate(19200);
 $serial_port->parity("none");
 $serial_port->stopbits(1);
-$serial_port->dtr_active(1);
+$serial_port->dtr_active(1) or warn "Could not set dtr_active(1)";
 $serial_port->handshake("none");
 $serial_port->write_settings || die "Could not set up port\n";
 


### PR DESCRIPTION
I kept getting dtr errors in my logs and couldn't find which module/port it was coming from.
This patch will show where the error came from.