### PR TITLE
Only include the PLCBUS module if we actually need it.

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -1166,10 +1166,12 @@ sub read_table_A {
     }
     #-------------- End AD2 Objects -------------
     elsif($type =~ /PLCBUS_.*/){
-        use PLCBUS;
         $packages{PLCBUS}++;
         ( $address, $name, $grouplist, @other) = @item_info;
         ($object,$grouplist,$additional_code) = PLCBUS->generate_code($type, @item_info);
+        if( ! $packages{PLCBUS}++ ) {   # first time for this object type?
+            $code .= "use PLCBUS;\n";
+        }
     }
     else {
         print "\nUnrecognized .mht entry: $record\n";


### PR DESCRIPTION
Otherwise we require users to install supporting modules for PLCBUS.