### PR TITLE
Fix for continuous reconnect to Squeezeserver.

### DIFF
--- a/lib/SqueezeboxCLI.pm
+++ b/lib/SqueezeboxCLI.pm
@@ -132,7 +132,7 @@ sub reconnect_delay {
 sub check_for_data {
     my ($self) = @_;
 
-    unless ( $$self{squeezecenter}->connected() ) {
+    unless ( $$self{squeezecenter}->connected() || $$self{reconnect_timer}->active() ) {
         $self->reconnect_delay();
         return;
     }


### PR DESCRIPTION
In case the connection went down the retry was not working correctly. The timer was restarted continuously, now it is only started once.