### PR TITLE
fix usage of mh.private.ini raZberry debug setting

### DIFF
--- a/lib/raZberry.pm
+++ b/lib/raZberry.pm
@@ -136,8 +136,8 @@ sub new {
     $self->{port}  = 8083;
     $self->{port}  = $port if ($port);
     $self->{debug} = 0;
-    $self->{debug} = $main::Debug{raZberry}
-      if ( defined $main::Debug{raZberry} );
+    $self->{debug} = $main::Debug{razberry}
+      if ( defined $main::Debug{razberry} );
     $self->{lastupdate} = undef;
     $self->{timeout}    = 2;
     $self->{timeout}    = $main::config_parms{raZberry_timeout}


### PR DESCRIPTION
the entries in $main::Debug are always lower case