### PR TITLE
prevent oopses about experimenal smartmatch operator

### DIFF
--- a/lib/Owfs_Item.pm
+++ b/lib/Owfs_Item.pm
@@ -88,6 +88,7 @@ use Socket_Item;
 
 package Owfs_Item;
 use strict;
+use experimental 'smartmatch';
 
 @Owfs_Item::ISA = ('Generic_Item');
 


### PR DESCRIPTION
this only adds

    use experimenal 'smartmach';

to prevent misterhouse from logging

    Oops1: Smartmatch is experimental at ../lib/Owfs_Item.pm line...

messages during startup.