### PR TITLE
Fix for Philips Hues controlled by external application

### DIFF
--- a/lib/Philips_Hue.pm
+++ b/lib/Philips_Hue.pm
@@ -144,9 +144,9 @@ sub default_setstate {
     my $cmnd = ( $state =~ /^off/i ) ? 'off' : 'on';
     $cmnd = $state if ( $state =~ /\%/ );
 
-    return -1
-      if ( $self->state eq $state )
-      ;    # Don't propagate state unless it has changed.
+    #return -1
+    #  if ( $self->state eq $state )
+    #  ;    # Don't propagate state unless it has changed.
 
     ::print_log( 'hue',
         "Request " . $self->get_object_name . " turn " . $cmnd );


### PR DESCRIPTION
Allow repeated control of same mode in case the light was controlled by an external application.

Use case: MisterHouse has turned the ligt off, another application turned it on. Then MisterHouse will refuse to turn the light off as it thinks the ligt is already off.