### PR TITLE
fix misterhouse http server behind nginx

### DIFF
--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -1639,7 +1639,7 @@ sub html_file {
         print "db web file cache check: f=$file t=$time2/$time3\n"
           if $main::Debug{http3};
         if ( $time3 <= $time2 ) {
-            return "HTTP/1.0 304 Not Modified\nServer: MisterHouse\n";
+            return "HTTP/1.0 304 Not Modified\nServer: MisterHouse\n\n";
         }
     }
 


### PR DESCRIPTION
this adds one additional newline after the response "304 Not Modified" header.
Before this change the missing newline made nginx think the connection
was aborted (nginx log: "upstream prematurely closed connection while reading response header from upstream")
And nginx sent "502 Bad Gateway" to the browser which made the page fail to load properly.