### PR TITLE
Add Travis CI regression test support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: perl
+perl:
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.08"
 install: true
 script: cd bin ; ./mh -tk 0 -code_dir ../code/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: perl
+install: true
+script: cd bin ; ./mh -tk 0 -code_dir ../code/test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MisterHouse
 ===========
 
+[![Build Status](https://travis-ci.org/hollie/misterhouse.svg?branch=master)](https://travis-ci.org/hollie/misterhouse)
+
 Perl open source home automation program. It's fun, it's free, and it's entirely geeky.
 
 * [Quickstart Guide](https://github.com/hollie/misterhouse/wiki/Getting-started)

--- a/bin/mh
+++ b/bin/mh
@@ -3705,7 +3705,7 @@ sub exit_pgm {
         $sock->close() if $sock;
     }
 
-    # Use exit code 1 to mean we exited on purpose ... anything else
+    # Use exit code 0 to mean we exited on purpose ... anything else
     # we can use in mh_loop to mean accidental exit, 'better restart'
     if ($restart) {
         &print_log("Restarting mh");
@@ -3717,7 +3717,7 @@ sub exit_pgm {
         print "Bye Bye\n";
 
         #       exit 1;
-        POSIX::_exit(1);     # MUCH faster ... but no DESTROY or END called.
+        POSIX::_exit(0);     # MUCH faster ... but no DESTROY or END called.
     }
 }
 

--- a/bin/mhl
+++ b/bin/mhl
@@ -23,7 +23,7 @@ while [ 1 = 1 ]; do
     rc=$?
     echo mh rc=$rc
     
-    if [ $rc = 1 ]; then
+    if [ $rc = 0 ]; then
        echo mh exited normally
        exit
     fi

--- a/code/test/test_mh.pl
+++ b/code/test/test_mh.pl
@@ -1,0 +1,15 @@
+# Category=Test
+
+# At startup program a time to stop the test after one minute
+my  $shutdown_timer = new Timer; #noloop
+$shutdown_timer->set(60, \&shutdown); #noloop
+
+if ($Startup) {
+	$shutdown_timer->start();
+	print_log "Shutdown timer set";
+}
+
+sub shutdown {
+	print_log "Stopping self-test, exit...";
+	run_voice_cmd("Exit Mister House");
+}


### PR DESCRIPTION
This pull request adds the required files to run a basic regression test on the MisterHouse code using Travis.

All control is in the `.travis.yml` file in the root of the repository.

Every time somebody commits code, a new build is triggered on Travis.

The test code that is executed is:
```
mh -code_dir code/test
```

With the current code that is present in that folder, MisterHouse is started, runs for one minute and then exits.

Results are here: https://travis-ci.org/hollie/misterhouse/builds

Rationale:
 * to offer a framework that allows automatic code verification for new pull requests
 * to speed up acceptance of new pull requests that pass the tests

Note:
 * I had to change the exit code of MisterHouse to '0' for an intended exit (so that the test can stop at a certain point in time). That exit code used to be 1, and I changed both the exit code and the loop code that checks the exit code. We need to check if there are other uses of the exit code '1' that could be broken by this change
 * More test code needs to be added to the `code/test/` folder. E.g. performing a basic check if the web interface is up, adding specific test code for modules, ...

So: this is a start, I hope we can expand it to cover larger parts of the MisterHouse code.