### PR TITLE
New scheduling code, WeatherNOAA fixes, and documentation updates.

### DIFF
--- a/bin/get_weather
+++ b/bin/get_weather
@@ -11,6 +11,7 @@
 #  Latest version:
 #      http://misterhouse.net/mh/bin
 #  Change log:
+#    - 08/17/16  Updated to fix for changes in "nifty GEO::Weather module"
 #    - 01/20/99  Created.  Replaces filter_weather with the nifty Geo::Weather module
 #    - The rest of the change log is at the bottom of this file.
 #
@@ -21,31 +22,23 @@
 
 use strict;
 
-my ( $Pgm_Path, $Pgm_Name );
-
+my ($Pgm_Path, $Pgm_Name);
 BEGIN {
-    ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
+    ($Pgm_Path, $Pgm_Name) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
 }
 
-my ($Version) =
-  q$Revision$ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
+my ($Version) = q$Revision: 1.12 $ =~ /: (\S+)/; # Note: revision number is auto-updated by cvs
 
 #print "Command: $Pgm_Name @ARGV\n";
 #print "Version: $Version\n";
 
 use Getopt::Long;
 my %parms;
-if (
-    !&GetOptions(
-        \%parms,   "h",      "help", "v", "city:s", "zone:s",
-        "state:s", "data=s", "no_log"
-    )
-    or @ARGV
-    or ( $parms{h} or $parms{help} )
-  )
-{
-    print <<eof;
+if (!&GetOptions(\%parms, "h", "help", "v", "city:s", "zone:s", "state:s",
+                 "data=s", "no_log") or @ARGV or
+    ($parms{h} or $parms{help})) {
+    print<<eof;
 
 $Pgm_Name gets weather info
 
@@ -67,74 +60,75 @@ Usage:
                      into the data_dir/web directory
 
   Example:
-    $Pgm_Name -city Rochester -state MN
+    $Pgm_Name -city Rochester -state MN -zone MPX
 
 eof
     exit;
-}
+  }
 
-my ( $conditions, $forecast, %data );
+my ($conditions, $forecast, %data);
 my %config_parms;
 
 $parms{city}  = 'Rochester'  unless $parms{city};
-$parms{zone}  = $parms{city} unless $parms{zone};
+#RICK 160817
+#$parms{zone}  = $parms{city} unless $parms{zone};
+$parms{zone}  = 'MPX' unless $parms{zone};
 $parms{state} = 'MN'         unless $parms{state};
 $parms{data}  = 'all'        unless $parms{data};
 $data{conditions}++ if $parms{data} eq 'all' or $parms{data} eq 'conditions';
 $data{forecast}++   if $parms{data} eq 'all' or $parms{data} eq 'forecast';
 
 use vars '$opt_v';
-$opt_v++ if $parms{v};    # Geo::Weather looks at this
+$opt_v++ if $parms{v};          # Geo::Weather looks at this
 
 my $caller = caller;
-my $return_flag = ( $caller and $caller ne 'main' ) ? 1 : 0;
+my $return_flag = ($caller and $caller ne 'main') ? 1 : 0;
 
 #use my_lib "$Pgm_Path/../lib/site"; # See note in lib/mh_perl2exe.pl for lib -> my_lib explaination
-BEGIN {
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site'";
-}                         # Use BEGIN eval to keep perl2exe happy
+BEGIN { eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site'" } # Use BEGIN eval to keep perl2exe happy
 
-require 'handy_utilities.pl';    # For read_mh_opts funcion
-&main::read_mh_opts( \%config_parms, $Pgm_Path );
+require 'handy_utilities.pl';       # For read_mh_opts funcion
+&main::read_mh_opts(\%config_parms, $Pgm_Path);
 
 use Geo::WeatherNOAA;
 
 $Geo::WeatherNOAA::proxy_from_env = 1;
 
-if ( $data{conditions} ) {
-    print "\nGetting the current weather for $parms{city}, $parms{state}\n";
-    $conditions =
-      print_current( $parms{city}, $parms{state}, undef, undef, undef, 1 );
+if ($data{conditions}) {
+    # Rick 160816
+    #print "\nGetting the current weather for $parms{city}, $parms{state}\n";
+    print "\nGetting the current weather for $parms{city}, $parms{state}, $parms{zone}\n";
+    #$conditions = print_current($parms{city}, $parms{state},undef,undef,undef,1);
+    $conditions = print_current($parms{city}, $parms{zone},undef,undef,undef,1);
+    # End Rick 160816
     $conditions =~ s/&deg;F/ degrees /;
     $conditions =~ s/ in\./ inches. /g;
 }
 
-if ( $data{forecast} ) {
-    print "Getting the forecast for $parms{zone}, $parms{state}\n";
-    $forecast =
-      print_forecast( $parms{zone}, $parms{state}, undef, undef, undef, 1 );
-    $forecast =~ s/Geo::WeatherNOAA.pm .+\n//;    # Drop geo version
-                                                  #$forecast =~ s/\.\.\./\. /g;
+if ($data{forecast}) {
+    # RICK 160817
+    #print "Getting the forecast for $parms{zone}, $parms{state}\n";
+    print "Getting the forecast for $parms{city}, $parms{state}, $parms{zone}\n";
+    #$forecast = print_forecast($parms{zone}, $parms{state},undef,undef,undef,1);
+    $forecast = print_forecast($parms{city}, $parms{zone},undef,undef,undef,1);
+
+    $forecast =~ s/Geo::WeatherNOAA.pm .+\n//; # Drop geo version
+    #$forecast =~ s/\.\.\./\. /g;
     $forecast =~ s/(\()(EDT|EST|CDT|CST|MDT|MST|PDT|PST)(\) *)//g;
 }
 
-unless ( $parms{no_log} ) {
-    file_write( "$config_parms{data_dir}/web/weather_conditions.txt",
-        $conditions )
-      if $data{conditions};
-    file_write( "$config_parms{data_dir}/web/weather_forecast.txt", $forecast )
-      if $data{forecast};
-
-    # Hmmm, this fails from a mh run command :(
-    #    system("\\mh\\bin\\house.bat show internet weather data");
-    #    system("\\mh\\bin\\speak hi");
-    #    sleep 3;
+unless ($parms{no_log}) {
+    file_write("$config_parms{data_dir}/web/weather_conditions.txt", $conditions) if $data{conditions};
+    file_write("$config_parms{data_dir}/web/weather_forecast.txt", $forecast) if $data{forecast};
+                                # Hmmm, this fails from a mh run command :(
+#    system("\\mh\\bin\\house.bat show internet weather data");
+#    system("\\mh\\bin\\speak hi");
+#    sleep 3;
 }
 
 if ($return_flag) {
-
-    # Dang ... a 'do pgm' can only return a scalar, not a list :(
-    if ( $data{conditions} ) {
+                                # Dang ... a 'do pgm' can only return a scalar, not a list :(
+    if ($data{conditions}) {
         return $conditions;
     }
     else {
@@ -142,24 +136,26 @@ if ($return_flag) {
     }
 }
 else {
-    if ( $data{conditions} ) {
-        print "\nCurrent conditions: $conditions\n";
+    if ($data{conditions}) {
+        #print "\nCurrent conditions: $conditions\n";
     }
-    if ( $data{forecast} ) {
-        print "\nThe forecast is $forecast\n\n";
-
-        #       print "The extended forecast is $forecast{EXTENDED}\n\n";
-        #       print "This information was updated $forecast{Date} and covers $forecast{Coverage}\n\n";
+    if ($data{forecast}) {
+        #print "\nThe forecast is $forecast\n\n";
+#       print "The extended forecast is $forecast{EXTENDED}\n\n";
+#       print "This information was updated $forecast{Date} and covers $forecast{Coverage}\n\n";
     }
 }
 
 # WeatherNOAA methods:
-#	get_currentWX
-#	get_currentWX_html
-#	get_forecast
-#	print_forecast
+#       get_currentWX
+#       get_currentWX_html
+#       get_forecast
+#       print_forecast
 
 # $Log: get_weather,v $
+# Revision 1.13  2016/08/17 23:05:00 rick steeves
+# updated for changes in GEO::WeatherNOAA
+#
 # Revision 1.12  2005/01/23 23:21:18  winter
 # *** empty log message ***
 #

--- a/lib/DOORBIRD.pm
+++ b/lib/DOORBIRD.pm
@@ -1,18 +1,10 @@
 =head1 B<DOORBIRD>
 
-=head2 SYNOPSIS
-
-Doorbird module 
-written by Wayne Gatlin <wayne@razorcla.ws>
 
 =head2 DESCRIPTION
 
 Module for interfacing with the Doorbird line of IP Doorbells.  Monitors events
 sent by the doorbell such as doorbell button push, motion, built in door relay trigger.
-
-For more info about Doorbird doorbells see: https://www.doorbird.com/
-For more info about the Doorbird open LAN API see: https://www.doorbird.com/api
-
 
 =head2 CONFIGURATION
 
@@ -22,21 +14,21 @@ for the display of these objects as separate items in the MH interface and allow
 users to interact directly with these objects using the basic Generic_Item
 functions such as tie_event.
 
-The DOORBIRD_Bell and DOORBIRD_Motion objects are for tracking the state of the 
-doorbell bell button and the doorbell built in motion detector and are not for 
-controlling the doorbell from MH. 
+The DOORBIRD_Bell and DOORBIRD_Motion objects are for tracking the state of the
+doorbell bell button and the doorbell built in motion detector and are not for
+controlling the doorbell from MH.
 
 The DOORBIRD_Relay object is for tracking the state of the built-in "door relay"
 in the doorbell and to control the door relay and the doorbell IR light. The relay
-is a standard dry contact relay that could be used for any purpose.   
+is a standard dry contact relay that could be used for any purpose.
 
-Misterhouse receives the states of each object from the doorbell by configuring the 
+Misterhouse receives the states of each object from the doorbell by configuring the
 doorbell to send an HTTP get to MH when an action is realized, this method allows MH
-to track the states even when they have been triggered by the android app. The 
-configuration of the doorbell happens when MH is started, so the doorbell must be 
+to track the states even when they have been triggered by the android app. The
+configuration of the doorbell happens when MH is started, so the doorbell must be
 On and accessible by MH when MH is started.
 
-=head3 Interface Configuration
+=head2 Interface Configuration
 
 mh.private.ini configuration:
 
@@ -44,50 +36,22 @@ In order to allow for multiple doorbells, instance names are used.
 the following are prefixed with the instance name (DOORBIRD).
 
 The IP of the misterhouse server:
-DOORBIRD_mh_ip=192.168.1.10
+	DOORBIRD_mh_ip=192.168.1.10
 
-Wherein the format for the definition is:
-<instance>_mh_ip=<mh server ip>
-
-
-The port of the misterhouse server web: 
-DOORBIRD_mh_port=8080
-
-Wherein the format for the definition is:
-<instance>_mh_port=<mh server port>
-
+The port of the misterhouse server web:
+	DOORBIRD_mh_port=8080
 
 The IP of the doorbell:
-DOORBIRD_doorbell_ip=192.168.1.50
-
-Wherein the format for the definition is:
-<instance>_doorbell_ip=<doorbird ip>
-
+	DOORBIRD_doorbell_ip=192.168.1.50
 
 The username for the doorbell:
-DOORBIRD_user=doorbirduser
-
-Wherein the format for the definition is:
-<instance>_user=<username>
-
+	DOORBIRD_user=doorbirduser
 
 The password for the doorbell:
-DOORBIRD_password=doorbirdpass
-
-Wherein the format for the definition is:
-<instance>_password=<password>
+	DOORBIRD_password=doorbirdpass
 
 
-Optional to enable debugging log:
-debug=doorbird
-
-Wherein the format for the definition is:
-debug=<instance>
-
-debug logs are stored in the <data_dir>/logs/
-
-
-=head4 Defining the Interface Object 
+=head2 Defining the Interface Object
 
 In addition to the above configuration, you must also define the interface
 object.  The object can be defined in the user code.
@@ -100,34 +64,34 @@ Wherein the format for the definition is:
 
    $DOORBIRD = new DOORBIRD(INSTANCE);
 
-=head4 Bell Object
+=head2 Bell Object
 
-$DOORBIRD_Bell = new DOORBIRD_Bell('DOORBIRD', 1);
+	$DOORBIRD_Bell = new DOORBIRD_Bell('DOORBIRD', 1);
 
 Wherein the format for the definition is:
-$DOORBIRD_Bell = new DOORBIRD_Bell(INSTANCE, ENABLECONFIG);
+	$DOORBIRD_Bell = new DOORBIRD_Bell(INSTANCE, ENABLECONFIG);
 
 States:
 ON
 OFF
 
-=head4 Motion Object
+=head2 Motion Object
 
-$DOORBIRD_Motion = new DOORBIRD_Motion('DOORBIRD', 1);
+	$DOORBIRD_Motion = new DOORBIRD_Motion('DOORBIRD', 1);
 
 Wherein the format for the definition is:
-$DOORBIRD_Motion = new DOORBIRD_Motion(INSTANCE, ENABLECONFIG);
+	$DOORBIRD_Motion = new DOORBIRD_Motion(INSTANCE, ENABLECONFIG);
 
 States:
 ON
 OFF
 
-=head4 Relay Object
+=head2 Relay Object
 
-$DOORBIRD_Relay = new DOORBIRD_Relay('DOORBIRD', 1);
+	$DOORBIRD_Relay = new DOORBIRD_Relay('DOORBIRD', 1);
 
 Wherein the format for the definition is:
-$DOORBIRD_Relay = new DOORBIRD_Relay(INSTANCE, ENABLECONFIG);
+	$DOORBIRD_Relay = new DOORBIRD_Relay(INSTANCE, ENABLECONFIG);
 
 States:
 ON
@@ -141,27 +105,27 @@ LIGHT_ON  (to enable the IR light on the door bell)
 
 An example mh.private.ini:
 
-DOORBIRD_mh_ip=192.168.1.10
-DOORBIRD_mh_port=8080
-DOORBIRD_doorbell_ip=192.168.1.50
-DOORBIRD_user=doorbirduser
-DOORBIRD_password=doorbirdpass
+	DOORBIRD_mh_ip=192.168.1.10
+	DOORBIRD_mh_port=8080
+	DOORBIRD_doorbell_ip=192.168.1.50
+	DOORBIRD_user=doorbirduser
+	DOORBIRD_password=doorbirdpass
 
 
 An example user code:
 
-#noloop=start
-use DOORBIRD;
-$DOORBIRD = new DOORBIRD('DOORBIRD');
-$DOORBIRD_Bell = new DOORBIRD_Bell('DOORBIRD', 1);
-$DOORBIRD_Motion = new DOORBIRD_Motion('DOORBIRD', 1);
-$DOORBIRD_Relay = new DOORBIRD_Relay('DOORBIRD', 1);
-#noloop=stop
+	#noloop=start
+	use DOORBIRD;
+	$DOORBIRD = new DOORBIRD('DOORBIRD');
+	$DOORBIRD_Bell = new DOORBIRD_Bell('DOORBIRD', 1);
+	$DOORBIRD_Motion = new DOORBIRD_Motion('DOORBIRD', 1);
+	$DOORBIRD_Relay = new DOORBIRD_Relay('DOORBIRD', 1);
+	#noloop=stop
 
-if ($state = state_changed $DOORBIRD_Motion) {
-    run_voice_cmd 'start cam 8' if ($state eq 'on');
-    run_voice_cmd 'stop cam 8' if ($state eq 'off');
-}
+	if ($state = state_changed $DOORBIRD_Motion) {
+    	 run_voice_cmd 'start cam 8' if ($state eq 'on');
+    	 run_voice_cmd 'stop cam 8' if ($state eq 'off');
+	}
 
 =head2 INHERITS
 
@@ -192,7 +156,7 @@ sub new {
    $$self{user} = $::config_parms{$instance.'_user'};
    $$self{password} = $::config_parms{$instance.'_password'};
    my $year_mon = &::time_date_stamp( 10, time );
-   $$self{log_file} = $::config_parms{'data_dir'}.'/logs/'.$instance.'_'.$year_mon.'.log';
+   $$self{log_file} = $::config_parms{'data_dir'}."/logs/DOORBIRD.$year_mon.log";
 
    bless $self, $class;
 
@@ -251,7 +215,7 @@ sub configure_bell {
   use LWP::UserAgent;
   my $ua = LWP::UserAgent->new();
   $ua->timeout($httptimeout);
- my $req = $ua->get('http://'.$$self{user}.':'.$$self{password}.'@'.$$self{doorbell_ip}.'/bha-api/notification.cgi?url=http://'.$$self{mh_ip}.':'.$$self{mh_port}.'/mh/set?$'.$class.'?ON&user=&password=&event='.$type.'&subscribe=1');
+ my $req = $ua->get('http://'.$$self{user}.':'.$$self{password}.'@'.$$self{doorbell_ip}.'/bha-api/notification.cgi?url=http://'.$$self{mh_ip}.':'.$$self{mh_port}.'/mh/set;no_response?$'.$class.'?ON&user=&password=&event='.$type.'&subscribe=1');
 }
 
 
@@ -260,23 +224,40 @@ sub send_command {
   use LWP::UserAgent;
   my $ua = LWP::UserAgent->new();
   $ua->timeout($httptimeout);
-  $self->debug_log("[DOORBIRD] Sent request /bha-api/$type.cgi",4);
+  ::print_log("[DOORBIRD] Sent request /bha-api/$type.cgi");
  my $req = $ua->get('http://'.$$self{user}.':'.$$self{password}.'@'.$$self{doorbell_ip}.'/bha-api/'.$type.'.cgi');
 }
 
 
-=item C<debug_log()>
+=back
 
-Used to log messages to the specific  log file.
+=head1 B<DOORBIRD_Bell>
+
+=head2 SYNOPSIS
+
+User code:
+
+    $DOORBIRD_Bell = new DOORBIRD_Bell('DOORBIRD', 1);
+
+     Wherein the format for the definition is:
+    $DOORBIRD_Bell = new DOORBIRD_Bell(INSTANCE, ENABLECONFIG);
+
+See C<new()> for a more detailed description of the arguments.
+
+
+=head2 DESCRIPTION
+
+ Tracks doorbell button pushes in MH. 
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
 
 =cut
-
-sub debug_log {
-   my ($self, $text, $level) = @_;
-   my $instance = $$self{instance};
-   ::logit( $$self{log_file}, $text) if $main::Debug{lc($instance)};
-}
-
 
 package DOORBIRD_Bell;
 @DOORBIRD_Bell::ISA = ('Generic_Item');
@@ -288,10 +269,10 @@ Instantiates a new object.
 $doorbell = The DOORBIRD of the doorbell that this zone is found on
 
 $config = If you want this module to configure the DOORBIRD doorbell
-          to post updates to MH, then this value should be a 1, else 0.
-                  If you disable auto configure (0), you must manually configure
-                  the doorbell using the API with the MH URL you want the doorbell
-                  to post to.
+to post updates to MH, then this value should be a 1, else 0.
+If you disable auto configure (0), you must manually configure
+the doorbell using the API with the MH URL you want the doorbell
+to post to.
 
 
 =cut
@@ -311,24 +292,56 @@ sub new
 sub set {
     my ($self, $p_state, $p_setby, $p_response) = @_;
         if ($p_state eq 'ON') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Bell] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Bell] Received request "
+           . $p_state ." for ". $self->get_object_name);
          $self->SUPER::set($p_state,$p_setby);
          $self->set_with_timer('TON', 2, 'TOFF')
         }
         if ($p_state eq 'TOFF') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Bell] Received request OFF"
-            ." by timer for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Bell] Received request OFF"
+            ." by timer for ". $self->get_object_name);
          $self->SUPER::set('OFF','TIMER');
        }
         if ($p_state eq 'OFF') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Bell] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Bell] Received request "
+           . $p_state ." for ". $self->get_object_name);
          $self->SUPER::set('OFF','TIMER');
        }
 }
 
+=back
 
+=head1 B<DOORBIRD_Motion>
+
+=head2 SYNOPSIS
+
+User code:
+
+    $DOORBIRD_Motion = new DOORBIRD_Motion('DOORBIRD', 1);
+
+    Wherein the format for the definition is:
+    $DOORBIRD_Motion = new DOORBIRD_Motion(INSTANCE, ENABLECONFIG);
+
+    States:
+    ON
+    OFF
+
+See C<new()> for a more detailed description of the arguments.
+
+
+=head2 DESCRIPTION
+
+Tracks doorbell motion in MH. 
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
 
 package DOORBIRD_Motion;
 @DOORBIRD_Motion::ISA = ('Generic_Item');
@@ -340,10 +353,10 @@ Instantiates a new object.
 $doorbell = The DOORBIRD doorbell that this motion sensor is found on
 
 $config = If you want this module to configure the DOORBIRD doorbell
-          to post updates to MH, then this value should be a 1, else 0.
-                  If you disable auto configure (0), you must manually configure
-                  the doorbell using the API with the MH URL you want the doorbell
-                  to post to.
+to post updates to MH, then this value should be a 1, else 0.
+If you disable auto configure (0), you must manually configure
+the doorbell using the API with the MH URL you want the doorbell
+to post to.
 
 
 =cut
@@ -363,25 +376,61 @@ sub new
 sub set {
     my ($self, $p_state, $p_setby, $p_response) = @_;
         if ($p_state eq 'ON') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Motion] Received request "
+         ::print_log("[DOORBIRD::Motion] Received request "
            . $p_state ." for ". $self->get_object_name);
-         $self->SUPER::set($p_state,$p_setby,1);
+         $self->SUPER::set($p_state,$p_setby);
          $self->set_with_timer('TON', 20, 'TOFF')
         }
         if ($p_state eq 'TOFF') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Motion] Received request OFF"
-            ." by timer for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Motion] Received request OFF"
+            ." by timer for ". $self->get_object_name);
          $self->SUPER::set('OFF','TIMER');
        }
         if ($p_state eq 'OFF') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Motion] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Motion] Received request "
+           . $p_state ." for ". $self->get_object_name);
          $self->SUPER::set('OFF','TIMER');
        }
 }
 
 
+=back
 
+=head1 B<DOORBIRD_Relay>
+
+=head2 SYNOPSIS
+
+User code:
+
+   $DOORBIRD_Relay = new DOORBIRD_Relay('DOORBIRD', 1);
+
+   Wherein the format for the definition is:
+   $DOORBIRD_Relay = new DOORBIRD_Relay(INSTANCE, ENABLECONFIG);
+
+States:
+ON
+OFF
+
+  Control States:
+  TOGGLE (to trigger the relay)
+  LIGHT_ON  (to enable the IR light on the door bell)
+
+See C<new()> for a more detailed description of the arguments.
+
+
+=head2 DESCRIPTION
+
+Tracks/controls doorbell relay in MH. 
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
 
 package DOORBIRD_Relay;
 @DOORBIRD_Relay::ISA = ('Generic_Item');
@@ -393,10 +442,10 @@ Instantiates a new object.
 $doorbell = The DOORBIRD doorbell that this door relay is found on
 
 $config = If you want this module to configure the DOORBIRD doorbell
-          to post updates to MH, then this value should be a 1, else 0.
-                  If you disable auto configure (0), you must manually configure
-                  the doorbell using the API with the MH URL you want the doorbell
-                  to post to.
+to post updates to MH, then this value should be a 1, else 0.
+If you disable auto configure (0), you must manually configure
+the doorbell using the API with the MH URL you want the doorbell
+to post to.
 
 
 =cut
@@ -409,37 +458,59 @@ sub new
    $doorbell = DOORBIRD::get_object_by_instance($doorbell);
    $doorbell->register($self,$config,$class);
    $$self{doorbell} = $doorbell;
-   @{$$self{states}} = ('TOGGLE','LIGHT-ON');
+   @{$$self{states}} = ('TOGGLE','LIGHT_ON');
    return $self;
 }
 
 sub set {
     my ($self, $p_state, $p_setby, $p_response) = @_;
         if ($p_state eq 'ON') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Relay] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Relay] Received request "
+           . $p_state ." for ". $self->get_object_name);
          $self->SUPER::set($p_state,$p_setby);
          $self->set_with_timer('TON', 2, 'TOFF')
         }
         if ($p_state eq 'TOFF') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Relay] Received request OFF"
-            ." by timer for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Relay] Received request OFF"
+            ." by timer for ". $self->get_object_name);
          $self->SUPER::set('OFF','TIMER');
        }
         if ($p_state eq 'OFF') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Relay] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
+         ::print_log("[DOORBIRD::Relay] Received request "
+           . $p_state ." for ". $self->get_object_name);
          $self->SUPER::set('OFF','TIMER');
        }
         if ($p_state eq 'TOGGLE') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Relay] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
-          $$self{doorbell}->send_command($object,'open-door',$class);
+         ::print_log("[DOORBIRD::Relay] Received request "
+           . $p_state ." for ". $self->get_object_name);
+          $$self{doorbell}->send_command($object,'open-door',$class)
        }
-        if ($p_state eq 'LIGHT-ON') {
-         $$self{doorbell}->debug_log("[DOORBIRD::Relay] Received request "
-           . $p_state ." for ". $self->get_object_name,1);
-         $$self{doorbell}->send_command($object,'light-on',$class);
+        if ($p_state eq 'LIGHT_ON') {
+         ::print_log("[DOORBIRD::Relay] Received request "
+           . $p_state ." for ". $self->get_object_name);
+         $self->send_command($object,'light-on',$class)
        }
 }
 
+
+=back
+
+=head2 INI PARAMETERS
+
+=head2 NOTES
+
+=head2 AUTHOR
+
+Wayne Gatlin <wayne@razorcla.ws>
+
+=head2 SEE ALSO
+
+=head2 LICENSE
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+=cut

--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -1944,7 +1944,15 @@ sub set_action {
     my ($self,$state) = @_;
 	 return if &main::check_for_tied_filters( $self, $state );
          $self->_set_schedule_active_state($state);
-         $self->set($state,'schedule',1);
+         my $sub = 'set';
+         $sub = $self->{sub} if defined($self->{sub});
+         $self->$sub($state,'schedule',1);
+}
+
+
+sub set_sub {
+  my ($self, $sub) = @_;
+  $self->{sub} = $sub;
 }
 
 

--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -133,15 +133,11 @@ sub new {
     $$self{state_now}     = undef;
     $$self{state_changed} = undef;
     $self->restore_data('sort_order');
-    $self->{logger_enable} = $main::config_parms{object_logger_enable} if (defined $main::config_parms{object_logger_enable});
-    $self->{logger_mintime} = 1;
-    $self->{logger_updatetime} = 0;
     $self->restore_data('active_state', 'schedule_count');
        for my $index (1..20) {
           $self->restore_data('schedule_'.$index, 'schedule_label_'.$index, 'schedule_once_'.$index);
        }
     $self->_initialize_schedule;
-
     return $self;
 }
 
@@ -1166,11 +1162,7 @@ sub logger {
 	my ($self,$state,$set_by_name,$target) = @_;
 	my $object_name = $self->{object_name};
 	$object_name =~ s/^\$//;
-	return if ($object_name eq "");
-	return if ($state eq "");
 	my $tickcount = int(&::get_tickcount()); #log in milliseconds
-	return if ($tickcount <  ($self->{logger_updatetime} + $self->{logger_mintime}));
-
 	#create directory structure if it doesn't exist
 	mkdir ($::config_parms{data_dir} . "/object_logs") unless (-d $::config_parms{data_dir} . "/object_logs");
 	mkdir ($::config_parms{data_dir} . "/object_logs/" . $object_name) unless (-d $::config_parms{data_dir} . "/object_logs/" . $object_name);
@@ -1178,7 +1170,6 @@ sub logger {
 	mkdir ($::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . $::Year . "/" . $::Month) unless (-d $::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . $::Year . "/" . $::Month);
 	#write the data to the log; time, ticks (milliseconds), object, state, set_by, target
 	&::logit ($::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . $::Year . "/" . $::Month . "/" . $::Mday . ".log", "$main::Time_Date,$tickcount,$object_name,$state,$set_by_name," . ( ($target) ? "$target" : '') ."\n",0);
-	$self->{logger_updatetime} = $tickcount;
 }
 	
 =item C<reset_states2()>
@@ -1283,39 +1274,14 @@ sub xPL_enable {
 
 =item C<logger_enable()>
 
-Will start logging state changes to a historical log file
+TODO.  Can only be run at startup or reload.
 
 =cut
 
 sub logger_enable {
+    return unless $main::Reload;
     my ( $self, $enable ) = @_;
-    if ($self->isa('Group') and (defined $main::config_parms{object_logger_group})) {
-    	$self->{logger_enable} = $main::config_parms{object_logger_group};
-    } else {
-    	$self->{logger_enable} = 1;
-    }
-}
-
-=item C<logger_disable()>
-
-Will stop logging state changes to a historical log file
-
-=cut
-
-sub logger_disable {
-    my ( $self, $enable ) = @_;
-    $self->{logger_enable} = 0;
-}
-
-=item C<logger_mintime()>
-
-Set the minimum number of seconds to log updates. Useful to 'throttle' noisey objects such as AD2 motion sensors
-
-=cut
-
-sub logger_mintime {
-    my ( $self, $mintime ) = @_;
-    $self->{logger_mintime} = $mintime;
+    $self->{logger_enable} = $enable;
 }
 
 =item C<get_logger_status()>
@@ -1342,14 +1308,13 @@ sub get_logger_data {
 	$object_name =~ s/^\$//;
 	my $data = "";
 	$epoch = $epoch - ($days * 60 * 60 * 24);
-	for (my $i = 0; $i <= $days; $i++) {
-		print "db i=$i, days=$days, epoch=$epoch\n";
-		my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($epoch + ($i * 60 * 60 * 24));
-		print "Epoch: $epoch is " . $mday . "/" . ($mon + 1) . "/" . ($year+1900) . "\n";
-		print "Checking " . $::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . "\n";		
-		print "Reading " . $::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . "\n" if ( -e	$::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . ".log");
+	for (my $i = 0; $i < $days; $i++) {
+		my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($epoch);
+		#print "Epoch: $epoch is $mday / " . ($mon + 1) . "/" . ($year+1900) . "\n";
+		#print "Checking " . $::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . "\n";		
+		#print "Reading " . $::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . "\n" if ( -e	$::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . ".log");
 		$data .= ::file_read($::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . ".log") if ( -e	$::config_parms{data_dir} . "/object_logs/" . $object_name . "/" . ($year + 1900) . "/" . ($mon + 1) . "/" . $mday . ".log");
-#		$epoch = $epoch + (60*60*24);
+		$epoch = $epoch + (60*60*24);
 	}
 
 	return $data;
@@ -1830,7 +1795,7 @@ sub _initialize_schedule {
    if ($self->{'schedule_count'} > 1) {
        ::print_log("[SCHEDULE] Initialize schedule for ". $self->get_object_name." Schedule count is ".$self->{'schedule_count'});
        $self->{'check_date_handler'} = sub { Generic_Item::check_date($self); };
-       ::MainLoop_post_add_hook( $self->{'check_date_handler'});
+       ::MainLoop_post_add_hook( $self->{'check_date_handler'}, 'persistent');
    }
 });
 }
@@ -1848,8 +1813,7 @@ sub set_schedule {
     my ($self,$index,$entry,$label) = @_;
     unless ( defined($self->{'check_date_handler'}) ) { 
 	$self->{'check_date_handler'} = sub { Generic_Item::check_date($self); }; 
-        #::MainLoop_post_add_hook( $self->{'check_date_handler'}, 'persistent'); 
-        ::MainLoop_post_add_hook( $self->{'check_date_handler'});
+        ::MainLoop_post_add_hook( $self->{'check_date_handler'}, 'persistent'); 
     }
 
     if ($index > $self->{'schedule_count'}) { $self->{'schedule_count'} = $index; }
@@ -2164,4 +2128,3 @@ MA  02110-1301, USA.
 #}
 
 1;
-

--- a/lib/Generic_Item.pm
+++ b/lib/Generic_Item.pm
@@ -1933,7 +1933,7 @@ sub check_date {
     for my $index (1..$self->{'schedule_count'}) {
          if (defined($self->{'schedule_'.$index})) {
 		::print_log("[SCHEDULE] Checking time for ". $self->get_object_name. " schedule is " . $self->{'schedule_'.$index} ." time_cron return ". &main::time_cron($self->{'schedule_'.$index}));
-                if (&main::time_cron($self->{'schedule_'.$index})) {::print_log("[SCHEDULE] Cron match for ". $self->get_object_name); $self->set_action($self->{'schedule_label_'.$index}) }
+                if (&main::time_cron($self->{'schedule_'.$index})) { $self->set_action($self->{'schedule_label_'.$index}) }
          }
        }
   }

--- a/lib/HARMON.pm
+++ b/lib/HARMON.pm
@@ -22,9 +22,9 @@ objects using the basic Generic_Item functions such as tie_event.
 There is a small difference in configuring the HARMON Interface for direct
 connections Serial or IP Connections (Ser2Sock).
 
-=head4 Direct Connections (USB or Serial)
 
-INI file:
+
+=head3 Direct Connections (USB or Serial) in INI file:
 
    HARMON_serial_port=/dev/ttyAMA0  @This is the serial device
    HARMON_baudrate=115200		  	@This must be 115200
@@ -32,41 +32,43 @@ INI file:
 Wherein the format for the parameter name is:
 
    HARMON_serial_port
-   HARMON_baudrate
-   
-=head4 IP Connections (Ser2Sock)
+   HARMON_baudrate  
 
-INI file:
 
-HARMON_server_ip=192.168.1.33 @IP address of the machine running ser2sock
-HARMON_server_port=36000 	  @Port configured in the ser2sock config
-HARMON_server_recon=10		  @Amount of time to wait before trying to reconnect
+=head3 IP Connections (Ser2Sock) in INI file:
+
+	HARMON_server_ip=192.168.1.33 @IP address of the machine running ser2sock
+	HARMON_server_port=36000 	  @Port configured in the ser2sock config
+	HARMON_server_recon=10		  @Amount of time to wait before trying to reconnect
 
 Wherein the format for the parameter name is:
 
-   HARMON-Prefix_server_ip
-   HARMON-Prefix_server_port
+	HARMON-Prefix_server_ip
+	HARMON-Prefix_server_port
 
-** In the ser2sock configuration you must enable "raw_device_mode = 1".
+**NOTE: In the ser2sock configuration you must enable "raw_device_mode = 1".
 
-=head4 Defining the Interface Object (All Connection Types)
+
+
+=head3 Defining the Interface Object (All Connection Types)
 
 In addition to the above configuration, you must also define the interface
 object.  The object can be defined in either an mht file or user code.
 
 In user code:
 
-   $HARMON = new HARMON('HARMON');
+	$HARMON = new HARMON('HARMON');
 
-Wherein the format for the definition is:
+	Wherein the format for the definition is:
 
-   $HARMON = new HARMON('HARMON');
+	$HARMON = new HARMON('HARMON');
+
 
 =head3 Power Configuration
 
 	$HARMON_POWER_Z1 = new HARMON_Power('HARMON', 1);
 
-Wherein the format for the definition is:
+	Wherein the format for the definition is:
 
 	<object_name> = new HARMON_Power(<receiver>, <zone_number>);
 
@@ -75,27 +77,25 @@ Wherein the format for the definition is:
 
 	$HARMON_VOLUME_Z1 = new HARMON_Volume('HARMON', 1);
 
-Wherein the format for the definition is:
+	Wherein the format for the definition is:
 
 	<object_name> = new HARMON_Volume(<receiver>, <zone_number>);
-
 
 
 =head3 Mute Configuration
 
 	$HARMON_MUTE_Z1 = new HARMON_Mute('HARMON', 1);
 
-Wherein the format for the definition is:
+	Wherein the format for the definition is:
 
 	<object_name> = new HARMON_Volume(<receiver>, <zone_number>);
-
 
 
 =head3 Input Configuration
 
 	$HARMON_INPUT_Z1 = new HARMON_Input('HARMON', 1);
 
-Wherein the format for the definition is:
+	Wherein the format for the definition is:
 
 	<object_name> = new HARMON_Volume(<receiver>, <zone_number>);
 
@@ -104,10 +104,11 @@ Wherein the format for the definition is:
 
 	$HARMON_CONTROL_Z1 = new HARMON_Control('HARMON', 1);
 
-Wherein the format for the definition is:
+	Wherein the format for the definition is:
 
 	<object_name> = new HARMON_Volume(<receiver>, <zone_number>);
 	
+
 =head2 TODO
 
 - Add the following commands and Acks:
@@ -116,8 +117,8 @@ Specification:
 Discrete Volume  
 
 When zone1 is on the Discrete volume command allows the user
-to enter a specific volume e.go. -63dB. When
-command received via RS232 –the AVR should
+to enter a specific volume eg: -63dB. When
+command received via RS232, the AVR should
 display the Volume OSD with the specified
 volume and adjust to that specified volume.
 50, 43, 53, 45, 4E, 44, 02, 04, 80, 70,
@@ -937,18 +938,18 @@ my %CmdAck = (
      if ($NewCmd =~ /(\w{20})(\w{20})/) { @NewCmds = ($1,$2) }
      else { push @NewCmds, $NewCmd } 
      foreach $NewCmd(@NewCmds) {
-	&main::print_log("[HARMON] - Hex $NewCmd - Lenght " . (length($NewCmd)) );
+	#&main::print_log("[HARMON] - Hex $NewCmd - Lenght " . (length($NewCmd)) );
        if ((length($NewCmd)) eq "20") {
              $AckMsg = ($CmdAck{"$NewCmd"});
              if ($AckMsg eq '') { $AckMsg = ($CmdAck{(substr ($NewCmd, 0, 18))});} # try stripping the checksum
              if ($AckMsg eq '') { $AckMsg = ($CmdAck{(substr ($NewCmd, 0, 16))});} # strip last 2 for vol caculations
-	     &main::print_log("[HARMON] - Ack $AckMsg - Hex $NewCmd ");
+	     #&main::print_log("[HARMON] - Ack $AckMsg - Hex $NewCmd ");
              $AckMsg = &GetAckMsg($AckMsg,$NewCmd) if &GetAckMsg($AckMsg,$NewCmd);
 	     my @AckMsgs;
 	     if ($AckMsg =~ /,/) { @AckMsgs = split(',', $AckMsg) }
 	     else { push @AckMsgs, $AckMsg  }
 	     foreach (@AckMsgs) {
-		  &main::print_log("[HARMON] - ACK MSG $_"); 
+		  #&main::print_log("[HARMON] - ACK MSG $_"); 
 		  if ( $_ =~ /^Z(\d)_(\w)_VOL_(.*)/ ) { $zone_num = $1; $msg = $3; }
                   elsif ( $_ =~ /^Z(\d)_(\w)_MUTE-(.*)/ ) { $zone_num = $1; $msg = $3; }
 		  elsif ( $_ =~ /^Z(\d)_(\w)_(.*)/ ) { $zone_num = $1; $msg = $3; } 
@@ -1032,7 +1033,7 @@ sub register {
 sub set {
    my ($self, $p_state, $p_setby, $p_response) = @_;
    my $instance = $$self{instance};
-   ::print_log("[HARMON] State: $p_state - Hex: $CmdMsg{$p_state}");
+   #::print_log("[HARMON] State: $p_state - Hex: $CmdMsg{$p_state}");
    my $cmd = ( exists $CmdMsg{$p_state} ) ? $CmdMsg{$p_state} : $p_state;
    $cmd = "504353454E440204$cmd";
    $cmd = pack('H*', $cmd);
@@ -1058,6 +1059,42 @@ sub set {
    return;
 }
 
+
+
+=back
+
+=head1 B<HARMON_Power>
+
+=head2 SYNOPSIS
+
+User code:
+
+
+        $HARMON_POWER_Z1 = new HARMON_Power('HARMON', 1);
+
+        Wherein the format for the definition is:
+
+        <object_name> = new HARMON_Power(<receiver>, <zone_number>);
+
+
+
+=head2 NOTES
+
+
+
+=head2 DESCRIPTION
+
+
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
 
 
 package HARMON_Power;
@@ -1115,6 +1152,42 @@ sub set_receive {
 }
 
 
+=back
+
+=head1 B<HARMON_Volume>
+
+=head2 SYNOPSIS
+
+User code:
+
+
+        $HARMON_VOLUME_Z1 = new HARMON_Volume('HARMON', 1);
+
+        Wherein the format for the definition is:
+
+        <object_name> = new HARMON_Volume(<receiver>, <zone_number>);
+
+
+
+=head2 NOTES
+
+
+
+=head2 DESCRIPTION
+
+
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
+
+
 package HARMON_Volume;
 @HARMON_Volume::ISA = ('Generic_Item');
 
@@ -1165,6 +1238,42 @@ sub set_receive {
     return $self->SUPER::set($p_state, $p_setby, $p_response);
     ::print_log("[HARMON::power] set to $p_state");
 }
+
+
+=back
+
+=head1 B<HARMON_Mute>
+
+=head2 SYNOPSIS
+
+User code:
+
+
+        $HARMON_MUTE_Z1 = new HARMON_Mute('HARMON', 1);
+
+        Wherein the format for the definition is:
+
+        <object_name> = new HARMON_Volume(<receiver>, <zone_number>);
+
+
+
+=head2 NOTES
+
+
+
+=head2 DESCRIPTION
+
+
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
 
 
 package HARMON_Mute;
@@ -1220,6 +1329,42 @@ sub set_receive {
 }
 
 
+=back
+
+=head1 B<HARMON_Input>
+
+=head2 SYNOPSIS
+
+User code:
+
+
+
+        $HARMON_INPUT_Z1 = new HARMON_Input('HARMON', 1);
+
+        Wherein the format for the definition is:
+
+        <object_name> = new HARMON_Volume(<receiver>, <zone_number>);
+
+
+
+=head2 NOTES
+
+
+
+=head2 DESCRIPTION
+
+
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
+
 
 package HARMON_Input;
 @HARMON_Input::ISA = ('Generic_Item');
@@ -1268,6 +1413,43 @@ sub set_receive {
     ::print_log("[HARMON::power] set to $p_state");
 }
 
+
+=back
+
+=head1 B<HARMON_Control>
+
+=head2 SYNOPSIS
+
+User code:
+
+
+        $HARMON_CONTROL_Z1 = new HARMON_Control('HARMON', 1);
+
+        Wherein the format for the definition is:
+
+        <object_name> = new HARMON_Volume(<receiver>, <zone_number>);
+
+
+
+=head2 NOTES
+
+
+
+=head2 DESCRIPTION
+
+
+
+=head2 INHERITS
+
+L<Generic_Item>
+
+=head2 METHODS
+
+=over
+
+=cut
+
+
 package HARMON_Control;
 @HARMON_Control::ISA = ('Generic_Item');
 
@@ -1309,3 +1491,23 @@ sub set {
                   $$self{receiver}->set($p_state);
                 }
  }
+
+=back
+
+=head2 NOTES
+
+=head2 AUTHOR
+
+Wayne Gatlin <wayne@razorcla.ws>
+
+=head2 SEE ALSO
+
+=head2 LICENSE
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+=cut

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -4,8 +4,9 @@ package SCHEDULE;
 
 sub new
 {
-   my ($class) = @_;
+   my ($class, $instance) = @_;
    my $self = new Generic_Item();
+   $$self{instance} = $instance;
    bless $self, $class;
    @{$$self{states}} = ('ON','OFF');
    return $self;
@@ -19,24 +20,43 @@ sub set {
         }
 
 sub set_schedule {
-	 my ($self, $type, $p_state) = @_;
-         $self{'schedule'}{'type'} = lc($type);
+         my ($self, $type, $p_state) = @_;
+         $$self{'schedule'}{'type'} = lc($type);
          my @cals;
-	 #$self{'type'} = 'calendar';
-	 #$self{'schedule'}{'7'}{'28'}{'20'}{'41'}{'action'} = 'start';
-	 #$self{'schedule'}{'7'}{'28'}{'20'}{'42'}{'action'} = 'stop';
-	  if ($p_state =~ /-/) { @cals = split /-/, $p_state } 
-	  else { @cals = ($p_state) } 
-	  foreach my $values (@cals) {
-	   my @calvals = split /,/, $values;
-	    $self{'schedule'}{$calvals[1]}{$calvals[2]}{$calvals[3]}{$calvals[4]}{'action'} = lc($calvals[0]) if ($type eq 'calendar');
-	    $self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'daily');
-            $self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'wdwe');
-            $self{'schedule'}{$calvals[1]}{$calvals[2]}{'action'} = lc($calvals[0]) if ($type eq 'time');
-	  }
+         #$self{'type'} = 'calendar';
+         #$self{'schedule'}{'7'}{'28'}{'20'}{'41'}{'action'} = 'start';
+         #$self{'schedule'}{'7'}{'28'}{'20'}{'42'}{'action'} = 'stop';
+          if ($p_state =~ /-/) { @cals = split /-/, $p_state }
+          else { @cals = ($p_state) }
+          foreach my $values (@cals) {
+           my @calvals = split /,/, $values;
+            $$self{'schedule'}{$calvals[1]}{$calvals[2]}{$calvals[3]}{$calvals[4]}{'action'} = lc($calvals[0]) if ($type eq 'calendar');
+            $$self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'daily');
+            $$self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'wdwe');
+            $$self{'schedule'}{$calvals[1]}{$calvals[2]}{'action'} = lc($calvals[0]) if ($type eq 'time');
+          }
  }
 
+ 
+sub am_i_active_object{
+  my ($self,$instance) = @_;
+  ::print_log("[SCHEDULE] - am_i_active_object - active object: ".$Interfaces{$instance}->get_object_name." check object: ".$self->get_object_name) if (defined($Interfaces{$instance}));
+  if (defined($Interfaces{$instance})) {
+     if ($Interfaces{$instance}->get_object_name eq $self->get_object_name) { return 1 }
+     else { return 0 } 
+  } else { return 0 }
+}
+ 
+sub get_instance_active_object{
+   my ($instance) = @_;
+   return $Interfaces{$instance};
+}
 
+
+sub _set_instance_active_object{
+   my ($self, $instance) = @_;
+   $Interfaces{$instance} = $self;
+}
 
 =item C<register()>
 
@@ -46,48 +66,199 @@ Used to associate child objects with the interface.
 
 sub register {
    my ($self, $object, $child, $start, $stop) = @_;
-   if ($object->isa('SCHEDULE_Generic')) {
+    if ($object->isa('SCHEDULE_Generic')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Generic" );
-	  push @{$self->{generic_object}}, $object;
-	  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
+          push @{$self->{generic_object}}, $object;
+          ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
+     }
+   if ($object->isa('SCHEDULE_Temp')) {
+      my $HorC = $child;
+      ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Temp" );
+            $self->{temp_object}{$HorC} = $object;
+	    if ((defined($self->{temp_object}{'cool'})) && (defined($self->{temp_object}{'heat'}))) {
+               	  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});}, 'persistent' );
+	     }
    }
 }
 
 
 
-sub check_date { 
-  my ($self,$object) = @_;
-  if ($::New_Minute) {
+sub check_date {
+ my ($self,$object) = @_;
+ my $occupied_state = ($$self{occupied}->state_now) if (defined($$self{occupied})); 
+ if ($occupied_state) { $self->ChangeACSetpoint if ($self->am_i_active_object($$self{instance})) }
+  
+ if ($::New_Minute) {
   ::print_log("[SCHEDULE] Checking schedule for ". $self->get_object_name." Sate is ". (state $self) . " Child object is ". $object->get_object_name);
-  if (lc(state $self) eq 'on') {
+   if (lc(state $self) eq 'on') {
      my $Week;
      if ($::Weekday) { $Week = 'weekday' } elsif ($::Weekend) { $Week = 'weekend' }
-     if (($self{'schedule'}{'type'} eq 'calendar') &&
-	   (defined(my $action = $self{'schedule'}{$::Month}{$::Mday}{$::Hour}{$::Minute}{'action'}))) {
-         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
-         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+     if (($$self{'schedule'}{'type'} eq 'calendar') &&
+        (defined(my $action = $$self{'schedule'}{$::Month}{$::Mday}{$::Hour}{$::Minute}{'action'}))) {
+	      &set_action($self,$object,$action);
        }
-      elsif (($self{'schedule'}{'type'} eq 'daily') &&
-	  (defined(my $action = $self{'schedule'}{lc($::Day)}{$::Hour}{$::Minute}{'action'}))) {
-         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
-         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+      elsif (($$self{'schedule'}{'type'} eq 'daily') &&
+          (defined(my $action = $$self{'schedule'}{lc($::Day)}{$::Hour}{$::Minute}{'action'}))) {
+	      &set_action($self,$object,$action);
        }
-      elsif (($self{'schedule'}{'type'} eq 'wdwe') &&
-	  (defined(my $action = $self{'schedule'}{$Week}{$::Hour}{$::Minute}{'action'}))) {
-         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
-         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+      elsif (($$self{'schedule'}{'type'} eq 'wdwe') &&
+          (defined(my $action = $$self{'schedule'}{$Week}{$::Hour}{$::Minute}{'action'}))) {
+	      &set_action($self,$object,$action);
        }
-      elsif (($self{'schedule'}{'type'} eq 'time') &&
-	  (defined(my $action = $self{'schedule'}{$::Hour}{$::Minute}{'action'}))) {
-         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
-         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+      elsif (($$self{'schedule'}{'type'} eq 'time') &&
+          (defined(my $action = $$self{'schedule'}{$::Hour}{$::Minute}{'action'}))) {
+	      &set_action($self,$object,$action);
        }
     }
 
   }
 }
-	
-	
+
+sub setACSetpoint {
+  my ($self,$object) = @_;
+  my $cool_sp = $object->{temp_object}{'cool'}->state;
+  my $cool_temp_control = $object->{temp_object}{'cool'}{child};
+  my $cool_temp_control_sub = $object->{temp_object}{'cool'}{sub};
+  my $heat_sp = $object->{temp_object}{'heat'}->state;
+  my $heat_temp_control = $object->{temp_object}{'heat'}{child};
+  my $heat_temp_control_sub = $object->{temp_object}{'heat'}{sub};
+  $cool_temp_control->$cool_temp_control_sub($cool_sp);
+  $heat_temp_control->$heat_temp_control_sub($heat_sp);
+  
+
+  ::print_log("[SCHEDULE] running ".$cool_temp_control->get_object_name."->".$cool_temp_control_sub."(".$cool_sp.")");
+  ::print_log("[SCHEDULE] running ".$heat_temp_control->get_object_name."->".$heat_temp_control_sub."(".$heat_sp.")");
+  #&::change_setpoints($cool,$heat);
+}
+
+sub set_action {
+    my ($self,$object,$action) = @_;
+      if ($object->isa('SCHEDULE_Generic')) {
+         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
+	 $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+      }
+         elsif ($object->isa('SCHEDULE_Temp')) {
+         ::print_log("[SCHEDULE] set_action -  Temp object: ".$object->get_object_name." Parent object: ".$self->get_object_name);
+         $self->_set_instance_active_object($$self{instance});
+         #&reset_timer($self);
+         $self->ChangeACSetpoint;
+      }
+}
+
+sub set_occpuancy {
+  my ($self, $normal_state, $setback_state, $setback_object, $delay, $delay_setback, $tracked_object) = @_;
+  $$self{occ_state} = $normal_state;
+  $$self{occ_setback_state} = $setback_state;
+  $$self{occ_setback_object} = $setback_object;
+  $$self{thermo_timer_delay} = '60';
+  $$self{thermo_timer_delay} = $delay if (defined $delay);
+  $$self{thermo_timer_delay_setback} = '60';
+  $$self{thermo_timer_delay_setback} = $delay_setback if (defined $delay_setback);
+  $$self{occupied} = $::mode_occupied unless (defined $$self{occupied});
+  $$self{occupied} = $tracked_object if (defined $tracked_object);
+  $$self{thermo_timer} = ::Timer::new();
+}
+
+
+sub set_winter {
+  my ($self, $object, $temp) = @_;
+  $$self{winter_mode_object} = $object;
+  $$self{winter_mode_temp} = $temp
+}
+
+
+sub set_vacation {
+  my ($self, $object, $state) = @_;
+  $$self{vacation_mode_object} = $object;
+  $$self{vacation_mode_state} = $state;
+}
+
+ 
+sub ChangeACSetpoint {
+my ($self,$object) = @_;
+unless ($self->am_i_active_object($$self{instance})) { return 0 }
+my $occ_setback_object = $$self{occ_setback_object};
+my $occ_setback_state = $$self{occ_setback_state};
+my $occ_state = $$self{occ_state};
+my $object = $self;
+my $occupied_state = ($$self{occupied}->state) if (defined($$self{occupied}));
+
+print_log("[THERMO] - DEBUG --- in ChangeACSetpoint") if ($config_parms{"thermo_schedule"} eq 'debug');
+
+    if (&OverRide($self)) {
+	   $occ_setback_object = $$self{override_mode_setback_object} if defined($$self{override_mode_setback_object});
+	   $occ_setback_state = $$self{override_mode_setback_state} if defined($$self{override_mode_setback_state});
+	   $occ_state = $$self{override_mode_occ_state} if defined($$self{occ_state});
+	   $object = $$self{override_mode_object} if defined($$self{override_mode_object});
+    }
+		&main::print_log("[THERMO] - INFO - ChangeACSetpoint - " . $occupied_state ." ". $object->get_object_name ." state match:  $occ_state");
+       if ((defined($$self{occupied})) && ($$self{occupied}->state eq $occ_state)) {
+	    &main::print_log("[THERMO] - INFO - ChangeACSetpoint - occ state match ". $object->get_object_name ." setpoints, you are now $occ_state");
+           if ($$self{thermo_timer}->expired) {
+                &main::print_log("[THERMO] - INFO - setting ". $object->get_object_name ." setpoints, you are now $occ_state");
+                $self->setACSetpoint($object);
+            } else {  
+                $$self{thermo_timer}->set($$self{thermo_timer_delay}, sub {
+                   $self->ChangeACSetpoint;
+                });
+            }
+       } elsif ((defined($$self{occupied})) && ($$self{occupied}->state eq $occ_setback_state)) {
+           if ($$self{thermo_timer}->expired) {
+                &main::print_log("[THERMO] - INFO - setting setback ". $occ_setback_object->get_object_name ."setpoints, you are now $occ_setback_state");
+                $self->setACSetpoint($occ_setback_object);
+            } else { 
+                $$self{thermo_timer}->set($$self{thermo_timer_delay_setback}, sub {
+                   $self->ChangeACSetpoint;
+                });
+            }
+       } else {
+                $self->setACSetpoint($object);
+      }
+}
+
+
+sub OverRide {
+my ($self) = @_;
+my $occupied_state = ($$self{occupied}->state) if (defined($$self{occupied}));
+undef $$self{override_mode_setback_object};
+undef $$self{override_mode_setback_state};
+undef $$self{override_mode_occ_state};
+undef $$self{override_mode_object};
+  print_log("[THERMO] - DEBUG --- IN OVERRIDE") if ($config_parms{"thermo_schedule"} eq 'debug');
+  if ($occupied_state eq 'vacation') {
+         print_log("[THERMO] - DEBUG --- IN OVERRIDE --- VACATION") if ($config_parms{"thermo_schedule"} eq 'debug');
+		 $$self{override_mode_setback_object} = $$self{vacation_mode_object}; # override the setpoint if in vacation mode
+		 $$self{override_mode_setback_state} = $$self{vacation_mode_state}; # override the setback state if in vacation mode
+         return 1;
+  } elsif ($self->WinterMode) {
+        print_log("[THERMO] - DEBUG --- IN OVERRIDE --- WINTERMODE") if ($config_parms{"thermo_schedule"} eq 'debug');
+		$$self{override_mode_object} = $$self{winter_mode_object}; # override the setpoint if forcast temp is below config
+        return 1;
+  }
+ return 0;
+}
+
+
+sub WinterMode {
+return 1;  # temp for testing
+my ($self) = @_;
+    print_log("[THERMO] - DEBUG --- IN WINTERMODE") if ($config_parms{"thermo_schedule"} eq 'debug');
+   if ($::Weather{'Forecast Tonight'} =~ /lows in the ([\w ]+) (\d+)/i) {
+        print_log("[THERMO] - DEBUG --- IN WINTERMODE --- FORCAST --- $1 $2") if ($config_parms{"thermo_schedule"} eq 'debug');
+        my $fc = $2;
+        if (lc($1) =~ /mid/) { $fc = $fc + 3 } # Translate low, mid, and upper to a value
+        if (lc($1) =~ /up/) { $fc = $fc + 6 }
+           ##if the value we got from the weather script is equal
+            #or lower than our defined value, return the defined winter mode
+       if ($fc <= ($$self{winter_mode_temp})) {
+         print_log("[THERMO] - DEBUG --- IN WINTERMODE  ---- M1 --- LOWS -- $fc -- $$self{winter_mode_temp}") if ($config_parms{"thermo_schedule"} eq 'debug');
+         return 1;
+       }
+     return 0;
+   }
+ }
+ 
+
 package SCHEDULE_Generic;
 @SCHEDULE_Generic::ISA = ('Generic_Item');
 
@@ -104,8 +275,8 @@ sub new
    $parent->register($self,$child,$start,$stop);
    if (defined($start)) {
     @{$$self{states}} = ($start,$stop);
-   } else { 
-    @{$$self{states}} = ($child->get_states()); 
+   } else {
+    @{$$self{states}} = @{$$child{states}};
    }
    return $self;
 }
@@ -117,4 +288,53 @@ sub set {
     $self->SUPER::set($p_state,$p_setby,1);
 }
 
+
+package SCHEDULE_Temp;
+@SCHEDULE_Temp::ISA = ('Generic_Item');
+
+
+sub new
+{
+   my ($class, $parent, $HorC, $child, $sub) = @_;
+   my $self = new Generic_Item();
+   bless $self, $class;
+   $$self{parent} = $parent;
+   $$self{HorC} = $HorC;
+   $$self{child} = $child;
+   $$self{sub} = $sub;
+   @{$$self{states}} = ('up','down');
+   $parent->register($self,$HorC);
+   #@{$$self{states}} = (60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80);
+   return $self;
+}
+
+
+
+#sub set {
+#    my ($self, $p_state, $p_setby, $p_response) = @_;
+#    $self->SUPER::set($p_state,$p_setby,1);
+#}
+
+sub set {
+    my ($self, $p_state, $p_setby, $p_response) = @_;
+	my $current_state = $self->state; 
+	unless (defined($current_state)) { $current_state = '70' }
+        if ($p_state eq 'up') {
+         ::print_log("[SCHEDULE::TEMP] Received request "
+           . $p_state ." for ". $self->get_object_name); 
+                 $p_state = $current_state + 1;
+         $self->SUPER::set($p_state,$p_setby,1);
+        }
+        if ($p_state eq 'down') {
+         ::print_log("[SCHEDULE::TEMP] Received request "
+            . $p_state ." for ". $self->get_object_name);
+                 $p_state = $current_state - 1;
+         $self->SUPER::set($p_state,$p_setby,1);
+       }
+        if ($p_state =~ /(\d+)/) {
+         ::print_log("[SCHEDULE::TEMP] Received request "
+           . $p_state ." for ". $self->get_object_name,1);
+         $self->SUPER::set($p_state,$p_setby,1);;
+       }
+}
 

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -11,7 +11,7 @@ sub new
    @{$$self{states}} = ('ON','OFF');
    $self->restore_data('active_object', 'active_action', 'schedule_count');
     #for my $index (1..$self->{'schedule_count'}) {
-    for my $index (1..10) {
+    for my $index (1..20) {
       $self->restore_data('schedule_'.$index, 'schedule_label_'.$index, 'schedule_once_'.$index);
      }
    return $self;

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -54,22 +54,32 @@ sub set_schedule {
 
 
 sub get_schedule{
-   my ($self) = @_;
-   my @schedule;
+ my ($self,$label_only) = @_;
+ my @schedule;
+ my $count;
+ my $object = @{$self->{generic_object}}[0] if (@{$self->{generic_object}}[0]);
+  if ($label_only) {
+         if (defined($object->{state_count})) { $count = $object->{state_count}; }
+	 else {  $count = 7;}
+	 for my $index (1..$count) {
+    	   if (defined($object->{$index})) { $schedule[$index] = $object->{$index}; } 
+           else { $schedule[$index] = $index; }
+	 }
+   return \@schedule;
+  }
+     if ((defined($object->{state_count})) && ($object->{state_count} > $self->{'schedule_count'})) { $count = $object->{state_count} }
+     else { $count = $self->{'schedule_count'} } 
+ 
      $schedule[0][0] = 0;
      $schedule[0][1] = '0 0 5 1 1';
      $schedule[0][2] = 0;
-     for my $index (1..$self->{'schedule_count'}) {
+     for my $index (1..$count) {
         #::print_log("[SCHEDULE] - index - ".$index . " entry - ". $self->{'schedule_'.$index});
         #$[ = 1;
-		my $object = @{$self->{generic_object}}[0] if (@{$self->{generic_object}}[0]);
                 $schedule[$index][0] = $index;
                 $schedule[$index][1] = $self->{'schedule_'.$index};
-		if (defined($object->{$index})) { 
-                  $schedule[$index][2] = $object->{$index};
-		} else { 
-		  $schedule[$index][2] = $index;
-		}
+		if (defined($object->{$index})) { $schedule[$index][2] = $object->{$index}; } 
+		else { $schedule[$index][2] = $index; }
       }
    return \@schedule;
 }
@@ -385,7 +395,7 @@ sub new
    bless $self, $class;
    $$self{parent} = @_[1];
    $$self{child} = @_[2];
-   $$self{state_count} = ((scalar @_) - 2);
+   $$self{state_count} = ((scalar @_) - 3);
    my @states;
    for my $i (3..(scalar @_)) { if (defined @_[$i]) { $self->{$i-2}=@_[$i]; push (@states, @_[$i]); } }
    @{$$self{states}} = @states;
@@ -414,6 +424,7 @@ sub new
    $$self{HorC} = $HorC;
    $$self{child} = $child;
    $$self{sub} = $sub;
+   $$self{state_count} = 7;
    @{$$self{states}} = ('up','down');
    $parent->register($self,$HorC);
    return $self;

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -19,27 +19,37 @@ sub set {
          $self->SUPER::set($p_state,$p_setby,1);
         }
 
-sub set_schedule {
-         my ($self, $type, $p_state) = @_;
-         $$self{'schedule'}{'type'} = lc($type);
-         my @cals;
-         #$self{'type'} = 'calendar';
+#sub set_schedule {
+#         my ($self, $type, $p_state) = @_;
+#         $$self{'schedule'}{'type'} = lc($type);
+#         my @cals;
+#         #$self{'type'} = 'calendar';
          #$self{'schedule'}{'7'}{'28'}{'20'}{'41'}{'action'} = 'start';
          #$self{'schedule'}{'7'}{'28'}{'20'}{'42'}{'action'} = 'stop';
-          if ($p_state =~ /-/) { @cals = split /-/, $p_state }
-          else { @cals = ($p_state) }
-          foreach my $values (@cals) {
-           my @calvals = split /,/, $values;
-            $$self{'schedule'}{$calvals[1]}{$calvals[2]}{$calvals[3]}{$calvals[4]}{'action'} = lc($calvals[0]) if ($type eq 'calendar');
-            $$self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'daily');
-            $$self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'wdwe');
-            $$self{'schedule'}{$calvals[1]}{$calvals[2]}{'action'} = lc($calvals[0]) if ($type eq 'time');
-          }
- }
+#          if ($p_state =~ /-/) { @cals = split /-/, $p_state }
+#          else { @cals = ($p_state) }
+#          foreach my $values (@cals) {
+#           my @calvals = split /,/, $values;
+#            $$self{'schedule'}{$calvals[1]}{$calvals[2]}{$calvals[3]}{$calvals[4]}{'action'} = lc($calvals[0]) if ($type eq 'calendar');
+#            $$self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'daily');
+#            $$self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'wdwe');
+#            $$self{'schedule'}{$calvals[1]}{$calvals[2]}{'action'} = lc($calvals[0]) if ($type eq 'time');
+#          }
+# }
 
- 
+sub set_schedule {
+    my ($self, $entry) = @_;
+    push @{$self->{'schedule'}}, $entry if (defined($entry));
+}
+
+sub get_schedule{
+   my ($self) = @_;
+   return @{$self->{'schedule'}} if (defined(@{$self->{'schedule'}}));
+}
+
 sub am_i_active_object{
   my ($self,$instance) = @_;
+  unless (defined($instance)) { return 1 } 
   ::print_log("[SCHEDULE] - am_i_active_object - active object: ".$Interfaces{$instance}->get_object_name." check object: ".$self->get_object_name) if (defined($Interfaces{$instance}));
   if (defined($Interfaces{$instance})) {
      if ($Interfaces{$instance}->get_object_name eq $self->get_object_name) { return 1 }
@@ -57,6 +67,7 @@ sub _set_instance_active_object{
    my ($self, $instance) = @_;
    $Interfaces{$instance} = $self;
 }
+
 
 =item C<register()>
 
@@ -83,36 +94,55 @@ sub register {
 
 
 
+#sub check_date {
+# my ($self,$object) = @_;
+# my $occupied_state = ($$self{occupied}->state_now) if (defined($$self{occupied})); 
+# if ($occupied_state) { $self->ChangeACSetpoint if (($self->am_i_active_object($$self{instance})) && (lc(state $self) eq 'on')) }
+  
+# if ($::New_Minute) {
+#  ::print_log("[SCHEDULE] Checking schedule for ". $self->get_object_name." Sate is ". (state $self) . " Child object is ". $object->get_object_name);
+#   if (lc(state $self) eq 'on') {
+#     my $Week;
+#     if ($::Weekday) { $Week = 'weekday' } elsif ($::Weekend) { $Week = 'weekend' }
+#     if (($$self{'schedule'}{'type'} eq 'calendar') &&
+#        (defined(my $action = $$self{'schedule'}{$::Month}{$::Mday}{$::Hour}{$::Minute}{'action'}))) {
+#	      &set_action($self,$object,$action);
+#       }
+#      elsif (($$self{'schedule'}{'type'} eq 'daily') &&
+#          (defined(my $action = $$self{'schedule'}{lc($::Day)}{$::Hour}{$::Minute}{'action'}))) {
+#	      &set_action($self,$object,$action);
+#       }
+#      elsif (($$self{'schedule'}{'type'} eq 'wdwe') &&
+#          (defined(my $action = $$self{'schedule'}{$Week}{$::Hour}{$::Minute}{'action'}))) {
+#	      &set_action($self,$object,$action);
+#       }
+#      elsif (($$self{'schedule'}{'type'} eq 'time') &&
+#          (defined(my $action = $$self{'schedule'}{$::Hour}{$::Minute}{'action'}))) {
+#	      &set_action($self,$object,$action);
+#       }
+#    }
+#
+#  }
+#}
+
+
 sub check_date {
  my ($self,$object) = @_;
- my $occupied_state = ($$self{occupied}->state_now) if (defined($$self{occupied})); 
- if ($occupied_state) { $self->ChangeACSetpoint if ($self->am_i_active_object($$self{instance})) }
-  
+ my $occupied_state = ($$self{occupied}->state_now) if (defined($$self{occupied}));
+ if ($occupied_state) { $self->ChangeACSetpoint if (($self->am_i_active_object($$self{instance})) && (lc(state $self) eq 'on')) }
+
  if ($::New_Minute) {
   ::print_log("[SCHEDULE] Checking schedule for ". $self->get_object_name." Sate is ". (state $self) . " Child object is ". $object->get_object_name);
    if (lc(state $self) eq 'on') {
-     my $Week;
-     if ($::Weekday) { $Week = 'weekday' } elsif ($::Weekend) { $Week = 'weekend' }
-     if (($$self{'schedule'}{'type'} eq 'calendar') &&
-        (defined(my $action = $$self{'schedule'}{$::Month}{$::Mday}{$::Hour}{$::Minute}{'action'}))) {
-	      &set_action($self,$object,$action);
-       }
-      elsif (($$self{'schedule'}{'type'} eq 'daily') &&
-          (defined(my $action = $$self{'schedule'}{lc($::Day)}{$::Hour}{$::Minute}{'action'}))) {
-	      &set_action($self,$object,$action);
-       }
-      elsif (($$self{'schedule'}{'type'} eq 'wdwe') &&
-          (defined(my $action = $$self{'schedule'}{$Week}{$::Hour}{$::Minute}{'action'}))) {
-	      &set_action($self,$object,$action);
-       }
-      elsif (($$self{'schedule'}{'type'} eq 'time') &&
-          (defined(my $action = $$self{'schedule'}{$::Hour}{$::Minute}{'action'}))) {
-	      &set_action($self,$object,$action);
-       }
+    foreach my $values (@{$self->{'schedule'}}) {
+       my @calvals = split /,/, $values;
+         if (&::time_cron($calvals[1])) { &set_action($self,$object,$calvals[0]) } 
+       } 
     }
 
   }
 }
+
 
 sub setACSetpoint {
   my ($self,$object) = @_;
@@ -135,11 +165,12 @@ sub set_action {
     my ($self,$object,$action) = @_;
       if ($object->isa('SCHEDULE_Generic')) {
          ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
+         $self->_set_instance_active_object($$self{instance}) if (defined($$self{instance}));
 	 $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
       }
          elsif ($object->isa('SCHEDULE_Temp')) {
          ::print_log("[SCHEDULE] set_action -  Temp object: ".$object->get_object_name." Parent object: ".$self->get_object_name);
-         $self->_set_instance_active_object($$self{instance});
+         $self->_set_instance_active_object($$self{instance}) if (defined($$self{instance}));
          #&reset_timer($self);
          $self->ChangeACSetpoint;
       }
@@ -191,7 +222,7 @@ print_log("[THERMO] - DEBUG --- in ChangeACSetpoint") if ($config_parms{"thermo_
 	   $occ_state = $$self{override_mode_occ_state} if defined($$self{occ_state});
 	   $object = $$self{override_mode_object} if defined($$self{override_mode_object});
     }
-		&main::print_log("[THERMO] - INFO - ChangeACSetpoint - " . $occupied_state ." ". $object->get_object_name ." state match:  $occ_state");
+	&main::print_log("[THERMO] - INFO - ChangeACSetpoint - " . $occupied_state ." ". $object->get_object_name ." state match:  $occ_state");
        if ((defined($$self{occupied})) && ($$self{occupied}->state eq $occ_state)) {
 	    &main::print_log("[THERMO] - INFO - ChangeACSetpoint - occ state match ". $object->get_object_name ." setpoints, you are now $occ_state");
            if ($$self{thermo_timer}->expired) {

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -1,0 +1,120 @@
+package SCHEDULE;
+@SCHEDULE::ISA = ('Generic_Item');
+
+
+sub new
+{
+   my ($class) = @_;
+   my $self = new Generic_Item();
+   bless $self, $class;
+   @{$$self{states}} = ('ON','OFF');
+   return $self;
+}
+
+
+
+sub set {
+         my ($self, $p_state, $p_setby, $p_response) = @_;
+         $self->SUPER::set($p_state,$p_setby,1);
+        }
+
+sub set_schedule {
+	 my ($self, $type, $p_state) = @_;
+         $self{'schedule'}{'type'} = lc($type);
+         my @cals;
+	 #$self{'type'} = 'calendar';
+	 #$self{'schedule'}{'7'}{'28'}{'20'}{'41'}{'action'} = 'start';
+	 #$self{'schedule'}{'7'}{'28'}{'20'}{'42'}{'action'} = 'stop';
+	  if ($p_state =~ /-/) { @cals = split /-/, $p_state } 
+	  else { @cals = ($p_state) } 
+	  foreach my $values (@cals) {
+	   my @calvals = split /,/, $values;
+	    $self{'schedule'}{$calvals[1]}{$calvals[2]}{$calvals[3]}{$calvals[4]}{'action'} = lc($calvals[0]) if ($type eq 'calendar');
+	    $self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'daily');
+            $self{'schedule'}{lc($calvals[1])}{$calvals[2]}{$calvals[3]}{'action'}  = lc($calvals[0]) if ($type eq 'wdwe');
+            $self{'schedule'}{$calvals[1]}{$calvals[2]}{'action'} = lc($calvals[0]) if ($type eq 'time');
+	  }
+ }
+
+
+
+=item C<register()>
+
+Used to associate child objects with the interface.
+
+=cut
+
+sub register {
+   my ($self, $object, $child, $start, $stop) = @_;
+   if ($object->isa('SCHEDULE_Generic')) {
+      ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Generic" );
+	  push @{$self->{generic_object}}, $object;
+	  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
+   }
+}
+
+
+
+sub check_date { 
+  my ($self,$object) = @_;
+  if ($::New_Minute) {
+  ::print_log("[SCHEDULE] Checking schedule for ". $self->get_object_name." Sate is ". (state $self) . " Child object is ". $object->get_object_name);
+  if (lc(state $self) eq 'on') {
+     my $Week;
+     if ($::Weekday) { $Week = 'weekday' } elsif ($::Weekend) { $Week = 'weekend' }
+     if (($self{'schedule'}{'type'} eq 'calendar') &&
+	   (defined(my $action = $self{'schedule'}{$::Month}{$::Mday}{$::Hour}{$::Minute}{'action'}))) {
+         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
+         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+       }
+      elsif (($self{'schedule'}{'type'} eq 'daily') &&
+	  (defined(my $action = $self{'schedule'}{lc($::Day)}{$::Hour}{$::Minute}{'action'}))) {
+         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
+         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+       }
+      elsif (($self{'schedule'}{'type'} eq 'wdwe') &&
+	  (defined(my $action = $self{'schedule'}{$Week}{$::Hour}{$::Minute}{'action'}))) {
+         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
+         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+       }
+      elsif (($self{'schedule'}{'type'} eq 'time') &&
+	  (defined(my $action = $self{'schedule'}{$::Hour}{$::Minute}{'action'}))) {
+         ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$object->{$action});
+         $object->{child}->SUPER::set($object->{$action},$self->get_object_name,1);
+       }
+    }
+
+  }
+}
+	
+	
+package SCHEDULE_Generic;
+@SCHEDULE_Generic::ISA = ('Generic_Item');
+
+
+sub new
+{
+   my ($class, $parent, $child, $start, $stop) = @_;
+   my $self = new Generic_Item();
+   bless $self, $class;
+   $$self{parent} = $parent;
+   $$self{child} = $child;
+   $$self{start} = $start;
+   $$self{stop} = $stop;
+   $parent->register($self,$child,$start,$stop);
+   if (defined($start)) {
+    @{$$self{states}} = ($start,$stop);
+   } else { 
+    @{$$self{states}} = ($child->get_states()); 
+   }
+   return $self;
+}
+
+
+
+sub set {
+    my ($self, $p_state, $p_setby, $p_response) = @_;
+    $self->SUPER::set($p_state,$p_setby,1);
+}
+
+

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -303,13 +303,15 @@ sub register {
     if ($object->isa('SCHEDULE_Generic')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Generic" );
           push @{$self->{generic_object}}, $object;
-          ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
+          #::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
+          ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);});
      }
    if ($object->isa('SCHEDULE_Temp')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Temp" );
             $self->{temp_object}{$HorC} = $object;
 	    if ((defined($self->{temp_object}{'cool'})) && (defined($self->{temp_object}{'heat'}))) {
-               	  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});}, 'persistent' );
+               	  #::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});}, 'persistent' );
+                  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});});
 	     }
    }
 }

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -55,13 +55,23 @@ sub set_schedule {
 
 sub get_schedule{
    my ($self) = @_;
-    @{$self->{'schedule'}}[0] = '0 0 5 1 1';;
+   my @schedule;
+     $schedule[0][0] = 0;
+     $schedule[0][1] = '0 0 5 1 1';
+     $schedule[0][2] = 0;
      for my $index (1..$self->{'schedule_count'}) {
         #::print_log("[SCHEDULE] - index - ".$index . " entry - ". $self->{'schedule_'.$index});
         #$[ = 1;
-        @{$self->{'schedule'}}[$index] = $self->{'schedule_'.$index} if (defined($self->{'schedule_'.$index}));
+		my $object = @{$self->{generic_object}}[0] if (@{$self->{generic_object}}[0]);
+                $schedule[$index][0] = $index;
+                $schedule[$index][1] = $self->{'schedule_'.$index};
+		if (defined($object->{$index})) { 
+                  $schedule[$index][2] = $object->{$index};
+		} else { 
+		  $schedule[$index][2] = $index;
+		}
       }
-   return \@{$self->{'schedule'}} if (@{$self->{'schedule'}});
+   return \@schedule;
 }
 
 sub am_i_active_object{
@@ -233,7 +243,6 @@ sub setACSetpoint {
 
   ::print_log("[SCHEDULE] running ".$cool_temp_control->get_object_name."->".$cool_temp_control_sub."(".$cool_sp.")");
   ::print_log("[SCHEDULE] running ".$heat_temp_control->get_object_name."->".$heat_temp_control_sub."(".$heat_sp.")");
-  #&::change_setpoints($cool,$heat);
 }
 
 sub set_action {
@@ -376,8 +385,10 @@ sub new
    bless $self, $class;
    $$self{parent} = @_[1];
    $$self{child} = @_[2];
-   $$self{state_count} = ((scalar @_) - 3);
-   for my $i (3..(scalar @_)) { if (defined @_[$i]) { $$self{$i-3}=@_[$i]; push (@{$$self{states}}, @_[$i]); } }
+   $$self{state_count} = ((scalar @_) - 2);
+   my @states;
+   for my $i (3..(scalar @_)) { if (defined @_[$i]) { $self->{$i-2}=@_[$i]; push (@states, @_[$i]); } }
+   @{$$self{states}} = @states;
    $$self{parent}->register($self,$child);
    return $self;
 }
@@ -405,16 +416,10 @@ sub new
    $$self{sub} = $sub;
    @{$$self{states}} = ('up','down');
    $parent->register($self,$HorC);
-   #@{$$self{states}} = (60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80);
    return $self;
 }
 
 
-
-#sub set {
-#    my ($self, $p_state, $p_setby, $p_response) = @_;
-#    $self->SUPER::set($p_state,$p_setby,1);
-#}
 
 sub set {
     my ($self, $p_state, $p_setby, $p_response) = @_;

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -65,7 +65,7 @@ Used to associate child objects with the interface.
 =cut
 
 sub register {
-   my ($self, $object, $child, $start, $stop) = @_;
+   my ($self, $object, $child, $state1, $state2) = @_;
     if ($object->isa('SCHEDULE_Generic')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Generic" );
           push @{$self->{generic_object}}, $object;
@@ -240,7 +240,7 @@ undef $$self{override_mode_object};
 
 
 sub WinterMode {
-return 1;  # temp for testing
+#return 1;  # temp for testing
 my ($self) = @_;
     print_log("[THERMO] - DEBUG --- IN WINTERMODE") if ($config_parms{"thermo_schedule"} eq 'debug');
    if ($::Weather{'Forecast Tonight'} =~ /lows in the ([\w ]+) (\d+)/i) {
@@ -265,16 +265,16 @@ package SCHEDULE_Generic;
 
 sub new
 {
-   my ($class, $parent, $child, $start, $stop) = @_;
+   my ($class, $parent, $child, $state1, $state2) = @_;
    my $self = new Generic_Item();
    bless $self, $class;
    $$self{parent} = $parent;
    $$self{child} = $child;
-   $$self{start} = $start;
-   $$self{stop} = $stop;
-   $parent->register($self,$child,$start,$stop);
-   if (defined($start)) {
-    @{$$self{states}} = ($start,$stop);
+   $$self{1} = $state1;
+   $$self{2} = $state2;
+   $parent->register($self,$child,$state1,$state2);
+   if (defined($state1)) {
+    @{$$self{states}} = ($state1,$state2);
    } else {
     @{$$self{states}} = @{$$child{states}};
    }

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -73,15 +73,14 @@ sub get_schedule{
       $count = $object->{state_count};
       if ($count eq 0) {
 	@states = $object->{child}->get_states; 
-	unshift @states, 0;
+	#unshift @states, 0;
       } else { 
-	$states[0] = 0;
 	for my $index (1..$count) {
-	 $states[$index] = $object->{$index};
+	 $states[$index-1] = $object->{$index};
         }
       }
    }
-  else { $states[0]=0 }
+  else { $states[0]=undef }
 
      #if ((defined($object->{state_count})) && ($object->{state_count} > $self->{'schedule_count'})) { $count = $object->{state_count} }
      #else { $count = $self->{'schedule_count'} } 

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -13,6 +13,7 @@ sub new
     #for my $index (1..$self->{'schedule_count'}) {
     for my $index (1..10) {
       $self->restore_data('schedule_'.$index);
+      $self->restore_data('schedule_label_'.$index);
      }
    return $self;
 }
@@ -43,13 +44,16 @@ sub set {
 # }
 
 sub set_schedule {
-    my ($self,$index,$entry) = @_;
+    my ($self,$index,$entry,$label) = @_;
     #my $index = (split /,/, $entry)[0];
     #$[ = 1;
     #@{$self->{'schedule'}}[$index] = $entry if (defined($entry));
+    ::print_log("[SCHEDULE] - set_schedule - Index " . $index . " Schedule: ". $entry ." Label ". $label); 
     if ($index > $self->{'schedule_count'}) { $self->{'schedule_count'} = $index } 
     $self->{'schedule_'.$index} = $entry if (defined($entry));
-    $self->{'schedule_set_flag'} = 1;
+    undef $self->{'schedule_'.$index} unless ($entry);
+    $self->{'schedule_label_'.$index} = $label if (defined($label));
+    $self->{set_time} = $main::Time;
 }
 
 
@@ -70,17 +74,16 @@ sub get_schedule{
      if ((defined($object->{state_count})) && ($object->{state_count} > $self->{'schedule_count'})) { $count = $object->{state_count} }
      else { $count = $self->{'schedule_count'} } 
  
-     $schedule[0][0] = 0;
-     $schedule[0][1] = '0 0 5 1 1';
-     $schedule[0][2] = 0;
+     $schedule[0][0] = 0; #Index
+     $schedule[0][1] = '0 0 5 1 1'; #schedule
+     $schedule[0][2] = 0; #Label
      for my $index (1..$count) {
-        #::print_log("[SCHEDULE] - index - ".$index . " entry - ". $self->{'schedule_'.$index});
-        #$[ = 1;
-                $schedule[$index][0] = $index;
-                $schedule[$index][1] = $self->{'schedule_'.$index};
-		if (defined($object->{$index})) { $schedule[$index][2] = $object->{$index}; } 
-		else { $schedule[$index][2] = $index; }
-      }
+        $schedule[$index][0] = $index;
+        $schedule[$index][1] = $self->{'schedule_'.$index}; 
+	if ((defined($self->{'schedule_label_'.$index})) && ($self->{'schedule_label_'.$index} ne $index)) { $schedule[$index][2] = $self->{'schedule_label_'.$index} } 
+        elsif (defined($object->{$index})) { $schedule[$index][2] = $object->{$index}; } 
+	else { $schedule[$index][2] = $index; }
+     }
    return \@schedule;
 }
 

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -118,7 +118,7 @@ sub new
    $$self{instance} = $instance;
    bless $self, $class;
    @{$$self{states}} = ('ON','OFF');
-   $self->restore_data('active_object', 'active_action', 'schedule_count','winter_mode_track_flag');
+   $self->restore_data('active_object', 'active_action', 'schedule_count');
     #for my $index (1..$self->{'schedule_count'}) {
     for my $index (1..20) {
       $self->restore_data('schedule_'.$index, 'schedule_label_'.$index, 'schedule_once_'.$index);

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -93,12 +93,32 @@ sub get_schedule{
      $schedule[0][1] = '0 0 5 1 1'; #schedule
      $schedule[0][2] = 0; #Label
      $schedule[0][3] = \@states;
-     for my $index (1..$count) {
-           $schedule[$index][0] = $index;
-           $schedule[$index][1] = $self->{'schedule_'.$index}; 
-	   if (defined($self->{'schedule_label_'.$index}) ) { $schedule[$index][2] = $self->{'schedule_label_'.$index} } 
-	   else { $schedule[$index][2] = $index if (defined($object->{'schedule_'.$index})); }
-     }
+     my $nullcount = 0;
+      for my $index (1..$count) {
+         unless(defined($self->{'schedule_'.$index})) { 
+   	     $nullcount++; 
+   	     $self->{'schedule_label_'.$index} = undef; 
+   	     $self->{'schedule_once_'.$index} = undef; 
+   	     next; 
+   	  }
+         if (defined($self->{'schedule_'.$index})) { 
+   	      $self->{'schedule_'.($index-$nullcount)} = $self->{'schedule_'.$index};
+   	      $self->{'schedule_label_'.($index-$nullcount)} = $self->{'schedule_label_'.$index};
+   	      $self->{'schedule_once_'.($index-$nullcount)} = $self->{'schedule_once_'.$index};
+   	      $schedule[($index-$nullcount)][0] = ($index-$nullcount);
+   	      $schedule[($index-$nullcount)][1] = $self->{'schedule_'.$index};
+   		
+   	      if (defined($self->{'schedule_label_'.$index}) ) { $schedule[($index-$nullcount)][2] = $self->{'schedule_label_'.$index} }
+   	      else { $schedule[($index-$nullcount)][2] = ($index-$nullcount) }
+   		
+   	       unless (($index-$nullcount) eq $index) {
+   		  $self->{'schedule_'.$index} = undef; 
+   		  $self->{'schedule_label_'.$index} = undef; 
+   		  $self->{'schedule_once_'.$index} = undef; 
+   	        }
+   	  }
+   }
+   $self->{'schedule_count'} = scalar @schedule;
    return \@schedule;
 }
 

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -44,7 +44,7 @@ sub set_schedule {
 
 sub get_schedule{
    my ($self) = @_;
-   return @{$self->{'schedule'}} if (defined(@{$self->{'schedule'}}));
+   return \@{$self->{'schedule'}} if (defined(@{$self->{'schedule'}}));
 }
 
 sub am_i_active_object{

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -247,7 +247,10 @@ sub set_action {
       if ($object->isa('SCHEDULE_Generic')) {
          ::print_log("[SCHEDULE] Setting ".$object->{child}->get_object_name." state to ".$self->{'schedule_label_'.$index});
          $self->_set_instance_active_object($$self{instance},$index) if (defined($$self{instance}));
-	 $object->{child}->SUPER::set($self->{'schedule_label_'.$index},$self->get_object_name,1);
+	 my $sub = 'set';
+	 $sub = $$self{sub} if defined($$self{sub});
+	 #$object->{child}->SUPER::set($self->{'schedule_label_'.$index},$self->get_object_name,1);
+         $object->{child}->$sub($self->{'schedule_label_'.$index},$self->get_object_name,1);
       }
          elsif ($object->isa('SCHEDULE_Temp')) {
          ::print_log("[SCHEDULE] set_action -  Temp object: ".$object->get_object_name." Parent object: ".$self->get_object_name);
@@ -397,6 +400,11 @@ sub set {
     $self->SUPER::set($p_state,$p_setby,1);
 }
 
+sub set_sub {
+  my ($self, $sub) = @_;
+  $$self{sub} = $sub;
+}
+
 
 package SCHEDULE_Temp;
 @SCHEDULE_Temp::ISA = ('Generic_Item');
@@ -442,3 +450,7 @@ sub set {
        }
 }
 
+sub set_sub {
+  my ($self, $sub) = @_;
+  $$self{sub} = $sub;
+}

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -44,7 +44,7 @@ sub set_schedule {
 
 sub get_schedule{
    my ($self) = @_;
-   return \@{$self->{'schedule'}} if (defined(@{$self->{'schedule'}}));
+   return \@{$self->{'schedule'}} if (@{$self->{'schedule'}});
 }
 
 sub am_i_active_object{
@@ -66,6 +66,13 @@ sub get_instance_active_object{
 sub _set_instance_active_object{
    my ($self, $instance) = @_;
    $Interfaces{$instance} = $self;
+}
+
+
+sub get_objects_for_instance {
+   my ($self) = @_;
+   my $instance = $$self{instance};
+   return \@{$Shedule_objects{$instance}} if defined($instance);
 }
 
 
@@ -282,7 +289,7 @@ my ($self) = @_;
            ##if the value we got from the weather script is equal
             #or lower than our defined value, return the defined winter mode
        if ($fc <= ($$self{winter_mode_temp})) {
-         print_log("[THERMO] - DEBUG --- IN WINTERMODE  ---- M1 --- LOWS -- $fc -- $$self{winter_mode_temp}") if ($config_parms{"thermo_schedule"} eq 'debug');
+         ::print_log("[THERMO] - DEBUG --- IN WINTERMODE  ---- M1 --- LOWS -- $fc -- $$self{winter_mode_temp}") if ($config_parms{"thermo_schedule"} eq 'debug');
          return 1;
        }
      return 0;
@@ -296,19 +303,14 @@ package SCHEDULE_Generic;
 
 sub new
 {
-   my ($class, $parent, $child, $state1, $state2) = @_;
+   my $class = @_[0];
    my $self = new Generic_Item();
    bless $self, $class;
-   $$self{parent} = $parent;
-   $$self{child} = $child;
-   $$self{1} = $state1;
-   $$self{2} = $state2;
-   $parent->register($self,$child,$state1,$state2);
-   if (defined($state1)) {
-    @{$$self{states}} = ($state1,$state2);
-   } else {
-    @{$$self{states}} = @{$$child{states}};
-   }
+   $$self{parent} = @_[1];
+   $$self{child} = @_[2];
+   $$self{state_count} = ((scalar @_) - 3);
+   for my $i (3..(scalar @_)) { if (defined @_[$i]) { $$self{$i-3}=@_[$i]; push (@{$$self{states}}, @_[$i]); } }
+   $$self{parent}->register($self,$child);
    return $self;
 }
 

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -303,15 +303,13 @@ sub register {
     if ($object->isa('SCHEDULE_Generic')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Generic" );
           push @{$self->{generic_object}}, $object;
-          #::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
-          ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);});
+          ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
      }
    if ($object->isa('SCHEDULE_Temp')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Temp" );
             $self->{temp_object}{$HorC} = $object;
 	    if ((defined($self->{temp_object}{'cool'})) && (defined($self->{temp_object}{'heat'}))) {
-               	  #::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});}, 'persistent' );
-                  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});});
+               	  ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$self->{temp_object}{'cool'});}, 'persistent' );
 	     }
    }
 }

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -185,14 +185,16 @@ Used to associate child objects with the interface.
 =cut
 
 sub register {
-   my ($self, $object, $child, $state1, $state2) = @_;
+   my ($self, $object, $child, $HorC) = @_;
+    $self->{schedule_object} = 1;
+    $object->{schedule_object} = 1;
+    $child->{schedule_object} = 1;
     if ($object->isa('SCHEDULE_Generic')) {
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Generic" );
           push @{$self->{generic_object}}, $object;
           ::MainLoop_pre_add_hook( sub {SCHEDULE::check_date($self,$object);}, 'persistent');
      }
    if ($object->isa('SCHEDULE_Temp')) {
-      my $HorC = $child;
       ::print_log("Registering a SCHEDULE Child Object type SCHEDULE_Temp" );
             $self->{temp_object}{$HorC} = $object;
 	    if ((defined($self->{temp_object}{'cool'})) && (defined($self->{temp_object}{'heat'}))) {
@@ -384,7 +386,7 @@ sub new
    my @states;
    for my $i (3..(scalar @_)) { if (defined @_[$i]) { $self->{$i-2}=@_[$i]; push (@states, @_[$i]); } }
    @{$$self{states}} = @states if (@states);
-   $$self{parent}->register($self,$child);
+   $$self{parent}->register($self,$$self{child});
    return $self;
 }
 
@@ -411,7 +413,7 @@ sub new
    $$self{sub} = $sub;
    $$self{state_count} = 7;
    @{$$self{states}} = ('up','down');
-   $parent->register($self,$HorC);
+   $parent->register($self,$child,$HorC);
    return $self;
 }
 

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -45,16 +45,22 @@ sub set {
 
 sub set_schedule {
     my ($self,$index,$entry,$label) = @_;
-    #my $index = (split /,/, $entry)[0];
-    #$[ = 1;
-    #@{$self->{'schedule'}}[$index] = $entry if (defined($entry));
     ::print_log("[SCHEDULE] - set_schedule - Index " . $index . " Schedule: ". $entry ." Label ". $label); 
     if ($index > $self->{'schedule_count'}) { $self->{'schedule_count'} = $index } 
     $self->{'schedule_'.$index} = $entry if (defined($entry));
-    undef $self->{'schedule_'.$index} unless ($entry);
     $self->{'schedule_label_'.$index} = $label if (defined($label));
+    unless ($entry) {
+	undef $self->{'schedule_label_'.$index};
+	undef $self->{'schedule_'.$index};
+    }
     $self->{set_time} = $main::Time;
 }
+
+
+sub delete_schedule {
+    my ($self,$index) = @_;
+    $self->set_schedule($index);
+}	
 
 
 sub get_schedule{

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -380,7 +380,7 @@ sub new
    $$self{state_count} = ((scalar @_) - 3);
    my @states;
    for my $i (3..(scalar @_)) { if (defined @_[$i]) { $self->{$i-2}=@_[$i]; push (@states, @_[$i]); } }
-   @{$$self{states}} = @states if (defined @states);
+   @{$$self{states}} = @states if (@states);
    $$self{parent}->register($self,$child);
    return $self;
 }

--- a/lib/SCHEDULE.pm
+++ b/lib/SCHEDULE.pm
@@ -14,7 +14,6 @@ sub new
     for my $index (1..10) {
       $self->restore_data('schedule_'.$index);
      }
-   sleep 1;
    return $self;
 }
 
@@ -44,9 +43,9 @@ sub set {
 # }
 
 sub set_schedule {
-    my ($self, $entry) = @_;
-    my $index = (split /,/, $entry)[0];
-    $[ = 1;
+    my ($self,$index,$entry) = @_;
+    #my $index = (split /,/, $entry)[0];
+    #$[ = 1;
     #@{$self->{'schedule'}}[$index] = $entry if (defined($entry));
     if ($index > $self->{'schedule_count'}) { $self->{'schedule_count'} = $index } 
     $self->{'schedule_'.$index} = $entry if (defined($entry));
@@ -56,9 +55,10 @@ sub set_schedule {
 
 sub get_schedule{
    my ($self) = @_;
+    @{$self->{'schedule'}}[0] = '0 0 5 1 1';;
      for my $index (1..$self->{'schedule_count'}) {
         #::print_log("[SCHEDULE] - index - ".$index . " entry - ". $self->{'schedule_'.$index});
-        $[ = 1;
+        #$[ = 1;
         @{$self->{'schedule'}}[$index] = $self->{'schedule_'.$index} if (defined($self->{'schedule_'.$index}));
       }
    return \@{$self->{'schedule'}} if (@{$self->{'schedule'}});
@@ -209,8 +209,9 @@ sub check_date {
    if (lc(state $self) eq 'on') {
     #foreach my $values (@{$self->{'schedule'}}) {
     for my $index (1..$self->{'schedule_count'}) {
-       my @calvals = split /,/, $self->{'schedule_'.$index};
-         if (&::time_cron($calvals[1])) { &set_action($self,$object,$calvals[0]) } 
+       #my @calvals = split /,/, $self->{'schedule_'.$index};
+        # if (&::time_cron($calvals[1])) { &set_action($self,$object,$calvals[0]) } 
+         if (&::time_cron($self->{'schedule_'.$index})) { &set_action($self,$object,$index) }
        } 
     }
 

--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -56,6 +56,12 @@ my %mime_types = (
     'wmlsc' => 'application/vnd.wap.wmlscriptc',
     'wrl'   => 'x-world/x-vrml',
     'json'  => 'application/json',
+    'svg'  => 'image/svg+xml',
+    'otf'  => 'application/font-sfnt',
+    'ttf' => 'application/font-sfnt',
+    'woff'   => 'application/font-woff',
+    'woff2'  => 'application/font-woff2',
+    'eot'  => 'application/vnd.ms-fontobject',
 );
 
 my ( %http_dirs, %html_icons, $html_info_overlib, %password_protect_dirs,

--- a/lib/site/Geo/WeatherNOAA.pm
+++ b/lib/site/Geo/WeatherNOAA.pm
@@ -1,5 +1,6 @@
-
-# $Id$
+# $Id: WeatherNOAA.pm,v 4.38 2006/12/10 21:58:11 msolomon Exp $
+# $Id: WeatherNOAA.pm,v 4.39 2016/08/17 21:58:11 rsteeves Exp $
+# $Id: WeatherNOAA.pm,v 4.40 2016/09/28 21:58:11 wgatlin Exp $
 
 
 package Geo::WeatherNOAA;
@@ -18,24 +19,32 @@ require Exporter;
 # names by default without a very good reason. Use EXPORT_OK instead.
 # Do not simply export all your public functions/methods/constants.
 @EXPORT = qw(
-	make_noaa_table
+        make_noaa_table
 
-	print_forecast
-	print_current
+        print_forecast
+        print_current
 
-	get_city_zone
-	process_city_zone
+        get_city_zone
+        process_city_zone
 
-	get_city_hourly
-	process_city_hourly
+        get_city_hourly
+        process_city_hourly
 );
 
-my $revision = '$Revision$';
-   $revision =~ m/: (\d+)/;
-   $revision = $1;
-   $VERSION  = $revision;
+$VERSION = do { my @r = (q$Revision: 4.40 $ =~ /\d+/g); sprintf "%d."."%02d" x $#r, @r };
+# my $URL_BASE = 'http://iwin.nws.noaa.gov/iwin/';
+# Rick 160817
+#my $URL_BASE = 'http://www.weather.gov/view/prodsByState.php?';
 
-my $URL_BASE = 'http://www.weather.gov/view/prodsByState.php';#'http://iwin.nws.noaa.gov/iwin/';
+# Wgatlin 160928
+#my $URL_BASE = 'http://www.srh.noaa.gov/data/';
+my $URL_BASE = 'http://forecast.weather.gov/product.php?site=';
+
+# Rick 160817 Temporary hack until I can figure out how to get the zone data
+# my $zone = 'RAH';
+
+
+# state=ia&prodtype=zone
 
 use vars '$proxy_from_env';
 $proxy_from_env = 0;
@@ -43,24 +52,24 @@ $proxy_from_env = 0;
 # Preloaded methods go here.
 
 sub print_forecast {
-	my ($city, $state, $filename, $fileopt, $UA) = @_;
-	my $in = get_city_zone($city,$state,$filename,$fileopt,$UA);
+        my ($city, $state, $filename, $fileopt, $UA) = @_;
+        my $in = get_city_zone($city,$state,$filename,$fileopt,$UA);
 
-	my $out;
+        my $out;
 
-	$out = "Geo::WeatherNOAA.pm v.$Geo::WeatherNOAA::VERSION\n";
+        $out = "Geo::WeatherNOAA.pm v.$Geo::WeatherNOAA::VERSION\n";
 
-	my ($date,$warnings,$forecast) = 
-	   process_city_zone($city,$state,$filename,$fileopt);
+        my ($date,$warnings,$forecast) =
+           process_city_zone($city,$state,$filename,$fileopt);
 
-	$out .= "As of $date:\n";
-	foreach my $warning (@$warnings) {
-		$out .= wrap('WARNING: ','    ',"$warning\n");
-	}
-	foreach my $key (keys %$forecast) {
-        	$out .= wrap('','    ',"$key: $forecast->{$key}\n");
-	}
-	return $out
+        $out .= "As of $date:\n";
+        foreach my $warning (@$warnings) {
+                $out .= wrap('WARNING: ','    ',"$warning\n");
+        }
+        foreach my $key (keys %$forecast) {
+                $out .= wrap('','    ',"$key: $forecast->{$key}\n");
+        }
+        return $out
 }
 
 
@@ -72,239 +81,279 @@ sub print_forecast {
 #########################################################################
 #########################################################################
 sub process_city_zone {
-	my ($city, $state, $filename, $fileopt, $UA) = @_;
-	my $in = get_city_zone($city,$state,$filename,$fileopt,$UA);
+        my ($city, $state, $filename, $fileopt, $UA) = @_;
+        my $in = get_city_zone($city,$state,$filename,$fileopt,$UA);
 
-	# Return error if problem getting URL
-	if ($in =~ /Error/) {
-		my %error;
-		my @null;
-		$error{'Error'} = 'Error';
-		$error{'Network Error'} = $in;
-		return ('',\@null,\%error);
-	}
+        # Return error if problem getting URL
+        if ($in =~ /Error/) {
+                my %error;
+                my @null;
+                $error{'Error'} = 'Error';
+                $error{'Network Error'} = $in;
+                return ('',\@null,\%error);
+        }
+        #print STDERR $in;exit;
 
-	# Split coverage, date, and forecast
-	#
-	my ($coverage, $date, $forecast) = ($in =~ /(^.*?)\012	# Coverage
-						    (\d.*?)\012	# Date
-						    (.*)/sx);	# Entire Forecast
-	
-	# Format Coverage
-	#
-	$coverage =~ s/corrected//gi;		# Remove stat word
-	$coverage =~ s/(\/|-|\.\.\.)/, /g;	# Turn weird punct to commas
-	$coverage =~ s/,\s*$//;			# Remove last comma
-	$coverage = ucfirst_words($coverage);	# Make caps correct
-	
-	# Format date (easy)
-	#
-	$date = format_date($date);
+        # Split coverage, date, and forecast
+        #
+        my ($coverage, $date, $forecast) = ($in =~ /(^.*?)\012  # Coverage
+                                                    (\d.*?)\012 # Date
+                                                    (.*)/sx);   # Entire Forecast
 
-	# Vars for forecast
-	#
-	my %forecast;
-	tie %forecast, "Tie::IxHash";
-	my @warnings;
+        # Format Coverage
+        #
+        $coverage =~ s/corrected//gi;           # Remove stat word
+        $coverage =~ s/(\/|-|\.\.\.)/, /g;      # Turn weird punct to commas
+        $coverage =~ s/,\s*$//;                 # Remove last comma
+        $coverage = ucfirst_words($coverage);   # Make caps correct
 
-	# Iterate through forecast and assign warnings to list or pairs to hash
-	#
-	my $forecast_item;	# Used as place holder for line breaks of $value
-	my $warnings_done = 0;	# Flag for warnings (Always at top of forcast)
+        # Format date (easy)
+        #
+        $date = format_date($date);
 
-	foreach my $line (split "\012",$forecast) {
-		# Be-gone if we've got temp data (will include parse for that later)
-		last if $line =~ /^\.</;
+        # Vars for forecast
+        #
+        my %forecast;
+        tie %forecast, "Tie::IxHash";
+        my @warnings;
 
-		my ($key,$value);
-		($key,$value) = ($line =~ /(.*?)\.\.\.(.*)/);
+        # Iterate through forecast and assign warnings to list or pairs to hash
+        #
+        my $forecast_item;      # Used as place holder for line breaks of $value
+        my $warnings_done = 0;  # Flag for warnings (Always at top of forcast)
 
-		if (! $value) {
-			# If there's no value, this must be either a warning or
-			# a continutation of value-data
-			$key = $line;
-		}
-		next if ($key =~ /EXTENDED/);
+        foreach my $line (split "\012",$forecast) {
+                # Be-gone if we've got temp data (will include parse for that later)
+                last if $line =~ /^\.</;
+
+                my ($key,$value);
+                ($key,$value) = ($line =~ /(.*?)\.\.\.(.*)/);
+
+                if (! $value) {
+                        # If there's no value, this must be either a warning or
+                        # a continutation of value-data
+                        $key = $line;
+                }
+                next if ($key =~ /EXTENDED/);
 
 
-		$warnings_done = 1 if ( ($key) and ($value) );
-		#print "WARN_DONE: $warnings_done\n";
+                $warnings_done = 1 if ( ($key) and ($value) );
+                #print "WARN_DONE: $warnings_done\n";
 
-		if ($warnings_done) {
-			if ( ($key =~ s/^\.//) and ($value) and ($key) ) {
-				# Add VALUE to KEY (new key)
-				$key =~ s/^\.//;
-				$key = ucfirst_words($key);
-				$forecast_item = $key;
-				$forecast{$forecast_item} .= $value;
-			}
-			elsif ( $forecast_item ) {
-				# Add KEY (with data) to OLD KEY (FORECAST_ITEM)
-				$forecast{$forecast_item} .= ' ' . $key;
-				$forecast{$forecast_item} .= ', ' . $value if $value;
-			}
-			else {
-				# print "LINE IGNORED\n";
-			}
-		}
-		elsif (! $warnings_done ) {                                     
-			if ( (!$key) and ($value) ) {                           
-					$value = ucfirst lc $value;                     
-					push @warnings, $value;                         
-			}                                                       
-			elsif ( ($key) and (!$value) ) {                        
-					$key = ucfirst lc $key;                         
-					push @warnings, $key;                           
-			}
-		}
-		else {
-			# line ignored
-		}
-	}
+                if ($warnings_done) {
+                        if ( ($key =~ s/^\.//) and ($value) and ($key) ) {
+                                # Add VALUE to KEY (new key)
+                                $key =~ s/^\.//;
+                                $key = ucfirst_words($key);
+                                $forecast_item = $key;
+                                $forecast{$forecast_item} .= $value;
+                        }
+                        elsif ( $forecast_item ) {
+                                # Add KEY (with data) to OLD KEY (FORECAST_ITEM)
+                                $forecast{$forecast_item} .= ' ' . $key;
+                                $forecast{$forecast_item} .= ', ' . $value if $value;
+                        }
+                        else {
+                                # print "LINE IGNORED\n";
+                        }
+                }
+                elsif (! $warnings_done ) {
+                        if ( (!$key) and ($value) ) {
+                                        $value = ucfirst lc $value;
+                                        push @warnings, $value;
+                        }
+                        elsif ( ($key) and (!$value) ) {
+                                        $key = ucfirst lc $key;
+                                        push @warnings, $key;
+                        }
+                }
+                else {
+                        # line ignored
+                }
+        }
 
-	foreach my $key ( keys %forecast ) {
-		$forecast{$key} =~ tr/\012//d;			# Remove newlines
-		#$forecast{$key} = lc($forecast{$key});	# No all CAPS
-		$forecast{$key} =~ s/\s+/ /g;			# Rid of multi-spaces
-		$forecast{$key} = sent_caps($forecast{$key});	# Proper sentance caps
-	}
+        foreach my $key ( keys %forecast ) {
+                $forecast{$key} =~ tr/\012//d;                  # Remove newlines
+                #$forecast{$key} = lc($forecast{$key}); # No all CAPS
+                $forecast{$key} =~ s/\s+/ /g;                   # Rid of multi-spaces
+                $forecast{$key} = sent_caps($forecast{$key});   # Proper sentance caps
+        }
 
-	return ($date,\@warnings,\%forecast,$coverage);
+        return ($date,\@warnings,\%forecast,$coverage);
 
 } # process_city_zone()
 
 
 sub get_city_zone {
-	my ($city, $state, $filename, $fileopt, $UA) = @_;
+        my ($city, $state, $filename, $fileopt, $UA) = @_;
 
-#	my $URL = $URL_BASE . lc $state . '/zone.html';
-	my $URL = $URL_BASE . '?state=' . lc $state . '&prodtype=zone';		
+        # my $URL = $URL_BASE . lc $state . '/zone.html';
+  # Rick 160817
+        #my $URL = $URL_BASE . 'state=' . lc($state) . '&prodtype=zone';
+  # Wgatlin 160928
+        #my $URL = $URL_BASE . $state . '/ZFP' . $state;
+        my $URL = $URL_BASE . $state .'&issuedby='. $state .'&product=ZFP&format=txt&version=1&glossary=0';
 
-	# City and States must be capital
-	#
-	$state = uc($state);
-	$city  = uc($city);
 
-	# Declare some working vars
-	#
-	my ($rawData, $coverage);
+        # City and States must be capital
+        #
+        $state = uc($state);
+        $city  = uc($city);
 
-	# Get data from filehandle object
-	#
-	$rawData = get_data($URL,$filename,$fileopt,$UA);
+        # Declare some working vars
+        #
+        my ($rawData, $coverage);
 
-        # required for new data format:
-	$rawData =~ s/\012\s/\012/g;
+        # Get data from filehandle object
+        #
+        $rawData = get_data($URL,$filename,$fileopt,$UA);
 
-	# Return error if there's an error
-	if ($rawData =~ /Error/) {
-		return $rawData;
-	}
-	# Find our city's data from all raw data
-	#
-	#foreach my $section ($rawData =~ /\012${state}Z.*?	# StateZone
-	foreach my $section ($rawData =~ /\012\w\wZ.*?	# StateZone
-					  \012(.*?)		# Data sect
-					  \012(?:\$\$|NNN)/xsg) {
-		# Iterate though section and get coverage
-		my $coverage_ended = 0;
-		foreach my $line (split /\012/, $section) {
-			$line =~ tr/\015//d; # \r
-			$coverage .= $line . "\n" if (! $coverage_ended);
-			if ($line !~ /^\w/) {
-				$coverage_ended = 1;
-			} 
-		}
-		return $section if ( ($coverage =~ /$city/i) && ($section =~ /\d{4}/));
-	}
-	return "$city not found";
+        # clean raw data to remove leading whitespace (I hope this works) 2006-12-10
+        #$rawData =~ s#\n\s*\.#\n.#gm;
+
+        #my $t1 = $rawData;
+        #$rawData =~ s#\r\n#\n#sg;
+        $rawData =~ s#\n\s+#\n#sg;
+
+        $rawData =~ s#\$\$#ENDOFSECTION#sg;
+
+
+        # print STDERR $rawData;
+        foreach my $line ($rawData =~ /\n(\w\wZ.*?)\012/sg) {
+                $line =~ s/\r//g;
+                $line =~ s/\n//g;
+                # print STDERR "HERE: " . $line . "\n";
+                my $pattern = "$line\\n(.*?)\\n(?:ENDOFSECTION|NNN)";
+                #print STDERR "PATTERN=" . $pattern . "<--\n";
+                my $section = ($rawData =~ /$pattern/sg)[0];
+                if ($section) {
+                        #print "\n\n$section\n";
+                        #print "   SIZE OF DATA: " . length($section) . "\n";
+                        # Iterate though section and get coverage
+                        my $coverage_ended = 0;
+                        foreach my $line (split /\012/, $section) {
+                                $line =~ tr/\015//d; # \r
+                                $coverage .= $line . "\n" if (! $coverage_ended);
+                                if ($line !~ /^\w/) {
+                                        $coverage_ended = 1;
+                                }
+                        }
+                        return $section if ( ($coverage =~ /$city/i) && ($section =~ /\d{4}/));
+                }
+        }
+        return "$city not found";
+
+        # Return error if there's an error
+        if ($rawData =~ /Error/) {
+                return $rawData;
+        }
+
+        # Find our city's data from all raw data
+        #
+        #foreach my $section ($rawData =~ /\012${state}Z.*?     # StateZone
+        foreach my $section ($rawData =~ /\013\w\wZ.*?  # StateZone
+                                          \012\013(.*?)         # Data sect
+                                          \012\013(?:\$\$|NNN)/xsg) {
+                # print STDERR "\n\nSECTION:\n$section\n";
+                # Iterate though section and get coverage
+                my $coverage_ended = 0;
+                foreach my $line (split /\012/, $section) {
+                        $line =~ tr/\015//d; # \r
+                        $coverage .= $line . "\n" if (! $coverage_ended);
+                        if ($line !~ /^\w/) {
+                                $coverage_ended = 1;
+                        }
+                }
+                return $section if ( ($coverage =~ /$city/i) && ($section =~ /\d{4}/));
+        }
+        return "$city not found";
 }
 
 ##############################################################################
 ##############################################################################
 ##
 ## Html for Mark's Site
-## 
+##
 ##############################################################################
 ##############################################################################
 
 sub font {
-	my $in = shift;
-	my $size = shift || 2;
-	my $font_face = $main::font_face || 'FACE="Helvetica, Lucida, Ariel"';
-	return qq|<FONT SIZE="$size" $font_face>$in</FONT>|;
+        my $in = shift;
+        my $size = shift || 2;
+        my $font_face = $main::font_face || 'FACE="Helvetica, Lucida, Ariel"';
+        return qq|<FONT SIZE="$size" $font_face>$in</FONT>|;
 }
 
 sub make_noaa_table {
-	my ($city, $state, $filename, $fileopt, $UA, $max_items) = @_;
+        my ($city, $state, $filename, $fileopt, $UA, $max_items) = @_;
 
-	$fileopt ||= 'get';
-	$max_items && $max_items--;
-	$max_items ||= 4;
-	
-	my $med_bg   = $main::med_bg || '#ddddff';
-	my $light_bg = $main::light_bg || '#eeeeff';
-	my $font_face = $main::font_face || 'FACE="Helvetica, Lucida, Ariel"';
+        $fileopt ||= 'get';
+        $max_items && $max_items--;
+        $max_items ||= 4;
 
-	my $locfilename;
-	$locfilename = $filename . "_hourly";
-	my $current = process_city_hourly( $city,$state,$locfilename,$fileopt,$UA );
-		
-	$locfilename = $filename . "_zone";
-	my ($date,$warnings,$forecast,$coverage) = process_city_zone( $city,$state,$locfilename,$fileopt,$UA);
-	my $cols = (keys %$forecast);
-	$cols = $max_items if $cols > $max_items;
-	my $out;
-	$out .= qq|<TABLE WIDTH="100%" CELLPADDING=1>\n|;
-	$out .= qq|<!-- Current weather row -->\n|;
-	$out .= qq|<TR VALIGN=TOP><TD BGCOLOR="$med_bg">\n|;
-	$out .= font('Current') . "\n</TD>\n";
-	$out .= qq|<TD COLSPAN="$cols">|;
-	$out .= font($current) . "\n</TD></TR>\n";
+        my $med_bg   = $main::med_bg || '#ddddff';
+        my $light_bg = $main::light_bg || '#eeeeff';
+        my $font_face = $main::font_face || 'FACE="Helvetica, Lucida, Ariel"';
 
-	# Add one to make cols real width of table
-	#
-	$cols++;
+        my $locfilename;
+        $locfilename = $filename . "_hourly";
+        my $current = process_city_hourly( $city,$state,$locfilename,$fileopt,$UA );
 
-	# Add warnings, if needed
-	#
-	if (@$warnings) {
-		$out .= qq|<!-- Warnings -->\n|;
-		foreach my $warning (@$warnings) {
-			$out .= qq|<TR BGCOLOR="#FF8389" ALIGN="CENTER">\n|;
-			$out .= qq|\t<TD COLSPAN="$cols">|;
-			$out .= qq|<FONT $font_face COLOR="#440000">\n|;
-			$out .= qq|\t$warning\n</TD></TR>\n|;
-		}
-	}
+        $locfilename = $filename . "_zone";
+        my ($date,$warnings,$forecast,$coverage) = process_city_zone( $city,$state,$locfilename,$fileopt,$UA);
+        my $cols = (keys %$forecast);
+        $cols = $max_items if $cols > $max_items;
+        my $out;
+        $out .= qq|<TABLE WIDTH="100%" CELLPADDING=1>\n|;
+        $out .= qq|<!-- Current weather row -->\n|;
+        $out .= qq|<TR VALIGN=TOP><TD BGCOLOR="$med_bg">\n|;
+        $out .= font('Current') . "\n</TD>\n";
+        $out .= qq|<TD COLSPAN="$cols">|;
+        $out .= font($current) . "\n</TD></TR>\n";
 
-	# Iterate over the first $max_items items in forecast
-	#
-	my $bottom; # add this after the iteration;
-	$out    .= qq|<TR VALIGN="TOP" BGCOLOR="$med_bg">\n|;
-	$bottom .= qq|<TR VALIGN="TOP">\n|;
-	foreach my $key ( (keys %$forecast)[0..($cols - 1)] ) {
-		#print STDERR "DEBUG: $key\n";
-		$out    .= "\t<TD>" . font($key) . "</TD>\n";
-		$bottom .= "\t<TD>" . font($forecast->{$key}) . "</TD>\n";
-	}
-	$out .= "</TR>\n" . $bottom . "</TR>\n";
-	
-	# Add coverage area
-	$out .= qq|<TR BGCOLOR="$light_bg" ALIGN="LEFT">\n|;
-	$out .= qq|	<TD>| . font('Area') . qq|</TD>\n|;
-	$out .= qq|	<TD COLSPAN="$cols">| . font($coverage,1) . qq|</TD>\n|;
-	$out .= qq|</TR>\n|;
+        # Add one to make cols real width of table
+        #
+        $cols++;
 
-	# Add credits
-	#
-	my $wx_cred = '<A HREF="http://www.noaa.gov">NOAA</A> forecast made ' .
-	  "$date by " .
-	  "<A HREF=\"http://www.seva.net/~msolomon/WeatherNOAA/dist/\">" .
-	  "Geo::WeatherNOAA</A> V.$Geo::WeatherNOAA::VERSION";
-	$out .= qq|<TR BGCOLOR="$light_bg" ALIGN="CENTER">\n|;
-	$out .= qq|<TD COLSPAN="$cols">| . font($wx_cred) . "</TD></TR>\n";
-	$out .= qq|</TABLE>\n|;
+        # Add warnings, if needed
+        #
+        if (@$warnings) {
+                $out .= qq|<!-- Warnings -->\n|;
+                foreach my $warning (@$warnings) {
+                        $out .= qq|<TR BGCOLOR="#FF8389" ALIGN="CENTER">\n|;
+                        $out .= qq|\t<TD COLSPAN="$cols">|;
+                        $out .= qq|<FONT $font_face COLOR="#440000">\n|;
+                        $out .= qq|\t$warning\n</TD></TR>\n|;
+                }
+        }
+
+        # Iterate over the first $max_items items in forecast
+        #
+        my $bottom; # add this after the iteration;
+        $out    .= qq|<TR VALIGN="TOP" BGCOLOR="$med_bg">\n|;
+        $bottom .= qq|<TR VALIGN="TOP">\n|;
+        foreach my $key ( (keys %$forecast)[0..($cols - 1)] ) {
+                #print STDERR "DEBUG: $key\n";
+                $out    .= "\t<TD>" . font($key) . "</TD>\n";
+                $bottom .= "\t<TD>" . font($forecast->{$key}) . "</TD>\n";
+        }
+        $out .= "</TR>\n" . $bottom . "</TR>\n";
+
+        # Add coverage area
+        $out .= qq|<TR BGCOLOR="$light_bg" ALIGN="LEFT">\n|;
+        $out .= qq|     <TD>| . font('Area') . qq|</TD>\n|;
+        $out .= qq|     <TD COLSPAN="$cols">| . font($coverage,1) . qq|</TD>\n|;
+        $out .= qq|</TR>\n|;
+
+        # Add credits
+        #
+        my $wx_cred = '<A HREF="http://www.noaa.gov">NOAA</A> forecast made ' .
+          "$date by " .
+          "<A HREF=\"http://www.seva.net/~msolomon/WeatherNOAA/dist/\">" .
+          "Geo::WeatherNOAA</A> V.$Geo::WeatherNOAA::VERSION";
+        $out .= qq|<TR BGCOLOR="$light_bg" ALIGN="CENTER">\n|;
+        $out .= qq|<TD COLSPAN="$cols">| . font($wx_cred) . "</TD></TR>\n";
+        $out .= qq|</TABLE>\n|;
 
 
 
@@ -314,77 +363,79 @@ sub make_noaa_table {
 ##############################################################################
 ##
 ## Misc funcs
-## 
+##
 ##############################################################################
 ##############################################################################
 
 sub get_url {
     my ($URL, $UA) = @_;
 
-	$URL or die "No URL to get!";
+        $URL or die "No URL to get!";
 
     # Create the useragent and get the data
     #
     if (! $UA) {
-	$UA = new LWP::UserAgent;
-        $UA->env_proxy if $proxy_from_env;
+                $UA = new LWP::UserAgent;
+                if ( $ENV{'HTTP_PROXY'} or $ENV{'http_proxy'} ) {
+                $UA->env_proxy;
+                }
     }
     $UA->agent("WeatherNOAA/$VERSION");
-    
+
     # Create a request
     my $req = new HTTP::Request GET => $URL;
     my $res = $UA->request($req);
-    if ($res->is_success) {	
-		return $res->content;
+    if ($res->is_success) {
+                return $res->content;
     }
     else {
-		return;
+                return;
     }
-} # getURL()    
+} # getURL()
 
 sub get_data {
-	my ($URL,$filename,$fileopt,$UA) = @_;
+        my ($URL,$filename,$fileopt,$UA) = @_;
 
-	$fileopt ||= 'get';
+        $fileopt ||= 'get';
 
-	my $data;	# Data
+        my $data;       # Data
 
-	if ( ($fileopt eq 'get') || ($fileopt eq 'save') ) {
-		print STDERR "Retrieving $URL\n" if $main::opt_v;
-		$data = get_url($URL,$UA) || 
-			return "Error getting data from $URL"; 
-		if ( $fileopt eq 'save' ) {
-			print STDERR "Writing $URL to $filename\n" if $main::opt_v;
-			open(OUT,">$filename") or die "Cannot create $filename";
-			print OUT $data;
-			close OUT;
-			$fileopt = 'usefile';
-		}
-	}
-	if ( $fileopt eq 'usefile' ) {
-		print STDERR "Reading data from $filename\n" if $main::opt_v;
-		open(FILE,$filename) or die "Cannot read $filename";
-		while (<FILE>) { $data .= $_; }
-	}
-	return $data;
+        if ( ($fileopt eq 'get') || ($fileopt eq 'save') ) {
+                print STDERR "Retrieving $URL\n" if $main::opt_v;
+                $data = get_url($URL,$UA) ||
+                        return "Error getting data from $URL";
+                if ( $fileopt eq 'save' ) {
+                        print STDERR "Writing $URL to $filename\n" if $main::opt_v;
+                        open(OUT,">$filename") or die "Cannot create $filename";
+                        print OUT $data;
+                        close OUT;
+                        $fileopt = 'usefile';
+                }
+        }
+        if ( $fileopt eq 'usefile' ) {
+                print STDERR "Reading data from $filename\n" if $main::opt_v;
+                open(FILE,$filename) or die "Cannot read $filename";
+                while (<FILE>) { $data .= $_; }
+        }
+        return $data;
 } # get_fh
 
 sub format_date {
-	my $in = shift;
-	$in =~ s/^(\d+)(\d\d)\s(AM|PM)\s(\w+)\s(\w+)\s(\w+)\s0*(\d+)/$1:$2\L$3\E ($4) \u\L$5\E\E \u\L$6 $7,/;
-	$in =~ tr/\015//d; # \r
-	return $in;
+        my $in = shift;
+        $in =~ s/^(\d+)(\d\d)\s(AM|PM)\s(\w+)\s(\w+)\s(\w+)\s0*(\d+)/$1:$2\L$3\E ($4) \u\L$5\E\E \u\L$6 $7,/;
+        $in =~ tr/\015//d; # \r
+        return $in;
 }
 sub sent_caps {
-	my $in = shift;
-	$in = ucfirst(lc($in));
-	$in =~ s/(\.\W+)(\w)/$1\U$2/g;		# Proper sentance caps
-	return $in;
+        my $in = shift;
+        $in = ucfirst(lc($in));
+        $in =~ s/(\.\W+)(\w)/$1\U$2/g;          # Proper sentance caps
+        return $in;
 }
 
 sub ucfirst_words {
-	my ($in) = @_;
-	return join " ", map ucfirst(lc($_)),(split /\s+/, $in);
+        my ($in) = @_;
+        return join " ", map ucfirst(lc($_)),(split /\s+/, $in);
 }
 
 #########################################################################
@@ -396,119 +447,129 @@ sub ucfirst_words {
 #########################################################################
 
 sub get_city_hourly {
-	my ($city,$state,$filename,$fileopt,$UA) = @_;
-	
-	# City and state in all caps please
-	#
-	$city  = uc $city;
-	$state = uc $state;
+        my ($city,$state,$filename,$fileopt,$UA) = @_;
 
-	# work var
-	my ($fields,$line,$date,$time);
-	
-	# Get data
-	#
-#	my $URL = $URL_BASE . lc $state . '/hourly.html';
-	my $URL = $URL_BASE . '?state=' . lc $state . '&prodtype=hourly';		
+        # City and state in all caps please
+        #
+        $city  = uc $city;
+        $state = uc $state;
 
-#print STDERR "Getting data\n";
-	my $data = get_data($URL,$filename,$fileopt,$UA);
-	#print STDERR "Got data\n";
+        # work var
+        my ($fields,$line,$date,$time);
 
-        # required for new data format:
-	$data =~ s/\012\s/\012/g;
+        # Get data
+        #
+        #my $URL = $URL_BASE . lc $state . '/hourly.html';
+  # Rick 160817
+  #my $URL = $URL_BASE . 'state=' . lc($state) . '&prodtype=hourly';
+  # Wgatlin 160928
+  #my $URL = $URL_BASE . $state . '/RWR' . $state;
+  my $URL = $URL_BASE . $state .'&issuedby='. $state .'&product=RWR&format=txt&version=1&glossary=0';
 
-	# Return error if there's an error
-	if ($data =~ /Error/) {
-		my %retHash;
-		$retHash{ERROR} = $data;
-		return \%retHash;
-	}
+  #print STDERR "Getting data from $URL\n";
+        my $data = get_data($URL,$filename,$fileopt,$UA);
+        my $datalength = length($data);
+        #print STDERR "Got data ($datalength)\n";
 
-	$data =~ s/\015//g; # \r
+        # Return error if there's an error
+        if ($data =~ /Error/) {
+                my %retHash;
+                $retHash{ERROR} = $data;
+                return \%retHash;
+        }
 
-	# Get line for our city from Data
-	#
-	foreach (split /\012/, $data) {
-		chomp;
-		$date   = $_ if /^\s*(\d+)(\d\d)\s+(AM|PM)\s+(\w+)/;
-		$time = "$1:$2 $3" if (($1) && ($2) && ($3));
-		$fields = $_ if /^CITY/;
-		$line   = $_ if /^$city\s/;
-		
-		# Newest data seems to be at the top of the file
-		last if $line;
-	}
-	$date = format_date($date);
+        $data =~ s/\015//g; # \r
 
-	# Set pack strings
-	#
-	my $fields_pack_str;
-	my $values_pack_str;
-	if ( ($fields =~ /TMP/) and ($fields =~ /\sDP\s/) ) {
-		#print STDERR "NEW FORMAT!\n";
-		$fields_pack_str = 
-        	'@0 A15 @15 A9 @25 A3 @29 A2 @33 A2 @36 A8 @47 A5 @54 A7';
-		$values_pack_str = 
-			'@0 A15 @15 A8 @24 A4 @28 A4 @32 A3 @36 A8 @46 A7 @53 A8';
-	}
-	else {
-		#print STDERR "OLD FORMAT!\n";
-		$fields_pack_str = 
-        	'@0 A15 @15 A9 @24 A5 @29 A5 @35 A4 @39 A8 @47 A8 @55 A8';
-		$values_pack_str = 
-			'@0 A15 @15 A9 @24 A5 @29 A5 @34 A4 @39 A8 @47 A8 @55 A8';
-	}
+        #print STDERR "LOOKING FOR: " . $city . "\n";
 
-	# unpack gives error of the string is smaller than the unpack string
-	$line .= ' ' x (64 - length($line)) if length($line) < 64;
-	
-	return { } unless ( ($line) && ($fields) ); # Return ref to empty hash
+        # Get line for our city from Data
+        #
+        foreach (split /\012/, $data) {
+                chomp;
+                s/^\s*//;
+                $date   = $_ if /^\s*(\d+)(\d\d)\s+(AM|PM)\s+(\w+)/;
+                $time = "$1:$2 $3" if (($1) && ($2) && ($3));
+                $fields = $_ if /^CITY/;
+    #RICK 160816
+    # My home city is RALEIGH-DURHAM, or RALEIGH, depending on which table
+                #$line   = $_ if /^$city\s/;
+                $line   = $_ if /^$city/;
 
-	my @fields;
-	push @fields, 'DATE', 'TIME', unpack $fields_pack_str, $fields if $fields;
+                #print STDERR "LINE: $line\n" if $line;
+
+                # Newest data seems to be at the top of the file
+                last if $line;
+        }
+        $date = format_date($date);
+
+        # Set pack strings
+        #
+        my $fields_pack_str;
+        my $values_pack_str;
+        if ( ($fields =~ /TMP/) and ($fields =~ /\sDP\s/) ) {
+                #print STDERR "NEW FORMAT!\n";
+                $fields_pack_str =
+                '@0 A15 @15 A9 @25 A3 @29 A2 @33 A2 @36 A8 @47 A5 @54 A7';
+                $values_pack_str =
+                        '@0 A15 @15 A8 @24 A4 @28 A4 @32 A3 @36 A8 @46 A7 @53 A8';
+        }
+        else {
+                #print STDERR "OLD FORMAT!\n";
+                $fields_pack_str =
+                '@0 A15 @15 A9 @24 A5 @29 A5 @35 A4 @39 A8 @47 A8 @55 A8';
+                $values_pack_str =
+                        '@0 A15 @15 A9 @24 A5 @29 A5 @34 A4 @39 A8 @47 A8 @55 A8';
+        }
+
+        # unpack gives error of the string is smaller than the unpack string
+        $line .= ' ' x (64 - length($line)) if length($line) < 64;
+
+        return { } unless ( ($line) && ($fields) ); # Return ref to empty hash
+
+        my @fields;
+        push @fields, 'DATE', 'TIME', unpack $fields_pack_str, $fields if $fields;
         #'@0 A15 @15 A9 @24 A5 @29 A5 @35 A4 @39 A8 @47 A8 @55 A8', $fields if $fields;
-	my @values;
-	push @values, $date, $time, unpack $values_pack_str, $line;
-	#print STDERR "$line\n";
-		#'@0 A15 @15 A9 @24 A5 @29 A5 @34 A4 @39 A8 @47 A8 @55 A8', $line;
+        my @values;
+        push @values, $date, $time, unpack $values_pack_str, $line;
+        #print STDERR "$line\n";
+                #'@0 A15 @15 A9 @24 A5 @29 A5 @34 A4 @39 A8 @47 A8 @55 A8', $line;
 
-	
 
-	return { } if $values[3] eq 'NOT AVBL'; # Return ref to empty hash
 
-	my %retValue;
-	foreach my $i (0..$#fields) {
-		# Convert odd fieldnames to standard
-		$fields[$i] = 'DEWPT' if $fields[$i] eq 'DP';
-		$fields[$i] = 'TEMP' if $fields[$i] eq 'TMP';
+        return { } if $values[3] eq 'NOT AVBL'; # Return ref to empty hash
 
-		# Assign value
-		$retValue{$fields[$i]} = $values[$i];
-	}
+        my %retValue;
+        foreach my $i (0..$#fields) {
+                # Convert odd fieldnames to standard
+                $fields[$i] = 'DEWPT' if $fields[$i] eq 'DP';
+                $fields[$i] = 'TEMP' if $fields[$i] eq 'TMP';
 
-	return \%retValue;
+                # Assign value
+                $retValue{$fields[$i]} = $values[$i];
+        }
+
+        return \%retValue;
 
 } # get_city_hourly()
 
 sub print_current {
-	my ($city,$state,$filename,$fileopt,$UA) = @_;
-	my $in = process_city_hourly($city, $state, $filename, $fileopt,$UA);
-	return wrap('','    ',$in)
+        my ($city,$state,$filename,$fileopt,$UA) = @_;
+        my $in = process_city_hourly($city, $state, $filename, $fileopt,$UA);
+        return wrap('','    ',$in)
 }
 
-	
+
 sub process_city_hourly {
-	my ($city,$state,$filename,$fileopt,$UA) = @_;
-	my $in = get_city_hourly($city, $state, $filename, $fileopt,$UA);
+        my ($city,$state,$filename,$fileopt,$UA) = @_;
+        my $in = get_city_hourly($city, $state, $filename, $fileopt,$UA);
 
-	$state = uc($state);
+        $state = uc($state);
 
-	return $in->{ERROR} if $in->{ERROR};
-	$in->{CITY} or return "No data available";
-	$in->{CITY} = ucfirst_words($in->{CITY});
-	
-	my %sky = (
+        return $in->{ERROR} if $in->{ERROR};
+        $in->{CITY} or return "No data available";
+        $in->{CITY} = ucfirst_words($in->{CITY});
+
+        my %sky = (
                'SUNNY'          => 'sunny skies',
                'MOSUNNY'        => 'mostly sunny skies',
                'PTSUNNY'        => 'partly sunny skies',
@@ -518,7 +579,7 @@ sub process_city_hourly {
                'MOCLDY'         => 'mostly cloudy skies',
                'PTCLDY'         => 'partly cloudy skies',
                'LGT RAIN'       => 'light rain',
-			   'FRZ DRZL'		=> 'freezing drizzle',
+                           'FRZ DRZL'           => 'freezing drizzle',
                'FLURRIES'       => 'flurries',
                'LGT SNOW'       => 'light snow',
                'SNOW'           => 'snow',
@@ -526,33 +587,47 @@ sub process_city_hourly {
                'NOT AVBL'       => '*not available*',
                'FAIR'           => 'fair weather');
 
-	# Format the wind direction and speed
-	#
-	my %compass = qw/N north S south E east W west/;
-#	my $direction = join '',map $compass{$_},split(/(\w)\d/g, $in->{WIND});
-	my $direction = join '',map $compass{$_},split(/(\w)\d/,  $in->{WIND}); # Drop /g to avoid perl 5.8 warning
-	my ($speed) = ($in->{WIND} =~ /(\d+)/);
-	my ($gusts) = ($in->{WIND} =~ /G(\d+)/);
+        # Format the wind direction and speed
+        #
+        my %compass = qw/N north S south E east W west/;
+        # my $direction = join '',map $compass{$_},split(/(\w)\d/g, $in->{WIND});
+        my $direction;
+        {
+                $direction = $in->{WIND};
+                $direction =~ s/(.*?)G.*/$1/;   # Remove gusts
+                $direction =~ s/\d//g;                  # Remove digits
+                if ( $direction ) {
+                        $direction = $compass{$direction};
+                }
+        }
+        my ($speed) = ($in->{WIND} =~ /(\d+)/);
+        my ($gusts) = ($in->{WIND} =~ /G(\d+)/);
 
-	if ($in->{WIND} eq 'CALM') {
-		$in->{WIND} = 'calm';
-	}
-	else {
-		$in->{WIND} = "$direction at ${speed} mph";
-		$in->{WIND} .= ", gusts up to ${gusts} mph" if $gusts;
-	}
+        if ($in->{WIND} eq 'CALM') {
+                $in->{WIND} = 'calm';
+        }
+        else {
+                $in->{WIND} = "$direction at ${speed} mph";
+                $in->{WIND} .= ", gusts up to ${gusts} mph" if $gusts;
+        }
 
-	# Format relative humidity and ibarometric pressure
-	#
-	my $rh_pres;
-    	if ($in->{RH}) {
-        	$rh_pres = " The relative humidity was $in->{RH}\%";
-    	}
-	if ($in->{PRES}) {
+        # Format relative humidity and ibarometric pressure
+        #
+        my $rh_pres;
+        if ($in->{RH}) {
+                $rh_pres = " The relative humidity was $in->{RH}\%";
+        }
+        if ($in->{PRES}) {
           my %rise_fall = qw/R rising S steady F falling/;
-# bbw Avoide a perl 5.8 warning
-#         my $direction = join '',map $rise_fall{$_},split(/\d(\w)/g, $in->{PRES});
-          my $direction = join '',map $rise_fall{$_},split(/\d(\w)/, $in->{PRES});
+          # my $direction = join '',map $rise_fall{$_},split(/\d(\w)/g, $in->{PRES});
+          my $direction;
+                  {
+                        $direction = $in->{PRES};
+                        $direction = ( $direction =~ /.*(\w)$/ )[0];
+                        if ( $direction ) {
+                                $direction = $rise_fall{$direction};
+                        }
+                  }
           $in->{PRES} =~ tr/RSF//d;
           if ($rh_pres) {
                 $rh_pres .= ", and b";
@@ -561,16 +636,18 @@ sub process_city_hourly {
                 $rh_pres .= " B";
           }
           $rh_pres .= "arometric pressure was $direction from $in->{PRES} in";
-    	}
-    	$rh_pres .= '.' if $rh_pres;
+        }
+        $rh_pres .= '.' if $rh_pres;
 
-	# Format output sentence
-	#
-	my $out;
-	$out  = "At $in->{TIME}, $in->{CITY}, $state conditions were ";
-	$out .= $sky{$in->{'SKY/WX'}} . " ";
-	$out .= "at $in->{TEMP}&deg;F, wind was $in->{WIND}. $rh_pres\n";
-	return $out;
+        # Format output sentence
+        #
+        my $out;
+# Rick 160817
+        #$out  = "At $in->{TIME}, $in->{CITY}, $state conditions were ";
+        $out  = "At $in->{TIME}, $in->{CITY} conditions were ";
+        $out .= $sky{$in->{'SKY/WX'}} . " ";
+        $out .= "at $in->{TEMP}&deg;F, wind was $in->{WIND}. $rh_pres\n";
+        return $out;
 
 } # process_city_hourly()
 
@@ -587,13 +664,13 @@ Geo::WeatherNOAA - Perl extension for interpreting the NOAA weather data
 =head1 SYNOPSIS
 
   use Geo::WeatherNOAA;
-  ($date,$warnings,$forecast,$coverage) = 
+  ($date,$warnings,$forecast,$coverage) =
      process_city_zone('newport','ri','','get');
 
   foreach $key (keys %$forecast) {
-  	print "$key: $forecast->{$key}\n";
+        print "$key: $forecast->{$key}\n";
   }
-  
+
   print process_city_hourly('newport news', 'va', '', 'get');
 
 or
@@ -653,65 +730,68 @@ if FILEOPT is "save"
 
 FILEOPT can be one of the following
 
-	- save
-		will get and save the data to FILENAME
-	- get
-		will retrieve new data (not store it)
-	- usefile
-		will not retrieve data from URL, 
-		use FILENAME for data
+        - save
+                will get and save the data to FILENAME
+        - get
+                will retrieve new data (not store it)
+        - usefile
+                will not retrieve data from URL,
+                use FILENAME for data
 
 The fifth argument is for a user created LWP::UserAgent(3) which can
-be configured to work with firewalls. See the LWP::UserAgent(3) manpage 
-for specific instructions. A basic example is like this: 
+be configured to work with firewalls. See the LWP::UserAgent(3) manpage
+for specific instructions. A basic example is like this:
 
    my $ua = new LWP::UserAgent;
    $ua->proxy(['http', 'ftp'], 'http://proxy.my.net:8080/');
 
-If you merely wish to set your proxy data from environment 
-variables (as in $ua-env_proxy>), simply set 
-
-   $Geo::WeatherNOAA::proxy_from_env = 1;
-
+NOTE: You may also set the environment variable <CODE>http_proxy</CODE>
+and the auto-generated LWP::UserAgent will use LWP::UserAgent::env_proxy().
+See LWP::UserAgent for more details.
 
 =item * process_city_zone(CITY,STATE,FILENAME,FILEOPT,LWP_UserAgent)
 
 Call CITY, STATE, FILENAME (explained above), FILEOPT(explained above),
 and UserAgent (Explained above).
 
+Note that in August 2016 the NOAA site stopped using STATE as the defining
+field, instead using 3-digit regional codes, available at:
+http://forecast.weather.gov/product_sites.php?site=CRH&product=ZFP
+All of the $state values should be the 3-digit code.
+
 The return is a three element list containing a) a string of the date/time
 of the forecast, b) a reference to the list of warnings (if any), and
 c) a reference to the hash of forecast.  I recommend calling it like this:
 
-    ($date, $warnings, $forecast, $coverage) = 
+    ($date, $warnings, $forecast, $coverage) =
         process_city_zone('newport news','va',
-	'/tmp/va_zone.html', 'save');
+        '/tmp/va_zone.html', 'save');
 
 Explanation of this call, it returns:
 
-	$date
-	- Scalar of the date of the forecast
+        $date
+        - Scalar of the date of the forecast
 
-	$warnings
-	- Reference to the warnings list
-	- EXAMPLE:
-	  foreach (@$warnings) { print; }
-	
-	$forecast
-	- Reference to the forecast KEY, VALUE pairs
-	- EXAMPLE:
-	  foreach $key (keys %$forecast) {
-	  	print "$key: $forecast->{$key}\n";
-	  }
+        $warnings
+        - Reference to the warnings list
+        - EXAMPLE:
+          foreach (@$warnings) { print; }
 
-	$coverage
-	- Scalar of the coverage area of the forecast
+        $forecast
+        - Reference to the forecast KEY, VALUE pairs
+        - EXAMPLE:
+          foreach $key (keys %$forecast) {
+                print "$key: $forecast->{$key}\n";
+          }
+
+        $coverage
+        - Scalar of the coverage area of the forecast
 
 
 =item * get_city_zone(CITY,STATE,FILENAME,FILEOPT,LWP_UserAgent)
 
 This sub is to get the block of data from the data source, which is
-chosen with the FILEOPTswitch.  
+chosen with the FILEOPTswitch.
 
 =item * get_city_hourly(CITY,STATE,FILENAME,FILEOPT,LWP_UserAgent)
 
@@ -722,7 +802,7 @@ and UserAgent.
 
 This function returns a reference to a hash containing the data. It
 
-Same FILEOPTand LWP_UserAgent from above, and process the 
+Same FILEOPTand LWP_UserAgent from above, and process the
 current weather data into an english sentence.
 
 =back
@@ -740,3 +820,4 @@ http://www.seva.net/~msolomon/
 perl(1), Tie::IxHash(3), LWP::Simple(3), LWP::UserAgent(3).
 
 =cut
+


### PR DESCRIPTION
Added SCHEDULE module for scheduling object state changes via the web UI. This is the backend code for Howard’s ia7 web code. There are 2 sub modules SCHEDULE_Temp and SCHEDULE_Generic. 
SCHEDULE_Temp is for thermostat scheduling. 
•	It allows users to control any thermostat connected to Misterhouse. 
•	It has objects for setting the thermostat temperatures for each schedule in the MH web UI. 
•	It has built in occupancy tracking for changing the thermostat temperature settings based on the time and if someone is home or not, including a vacation mode.
•	It has a built in outdoor temperature/forecast tracking to change the thermostat temperature settings based on the time and the forecasted temperature or the current outdoor temperature. 

SCHEDULE_Generic is for scheduling object state changes for objects that don’t inherit the scheduling code from the Generic_Item.

Generic_Item now has the scheduling code as well so all Generic_Item objects or objects that inherit Generic_Item will be able to have state changes scheduled via Howard's scheduling web UI code. The schedule check code is not added to the main loop until the user adds a schedule via the web UI and the code is removed from the main loop once all the schedule entries are removed.

Generic_Item has also been updated with Howard's logger code which allows you to graph object state changes in the Misterhouse UI. 

get_weather has the fixes from Rick Steeves.
WeatherNOAA has the fixes from Rick and I.

DOORBIRD.pm and HARMON.pm now have documentation that converts to HTML properly and can be viewed in the local Misterhouse POD documentation page.

DOORBIRD.pm has been updated to post back to Misterhouse using the no_response option. 


_Wayne
