### PR TITLE
minor omnistat fixes.

### DIFF
--- a/code/support/hai-omnistat/omnistat.pl
+++ b/code/support/hai-omnistat/omnistat.pl
@@ -234,8 +234,8 @@ foreach my $omnistat (@omnilist) {
             Omnistat::omnistat_log(
                 "$omniname[$omnistat] Omnistat: replace the filter", 0 );
 
-            # reset the timer to 6 months
-            $omnistat[$omnistat]->set_filter_reminder(180);
+            # reset the timer  to 30 days of runtime (59 max)
+            $omnistat[$omnistat]->set_filter_reminder(30);
         }
         else {
             Omnistat::omnistat_log(

--- a/lib/Omnistat.pm
+++ b/lib/Omnistat.pm
@@ -380,6 +380,8 @@ RC-112 34
 RC-120 48
 RC-121 49
 RC-122 50
+RC-1000: 110
+RC-2000: 120
 
 Outside Temperature: writing to the outside temperature register will cause the thermostat to display the
 outside temperature every 4 seconds. The thermostat will stop displaying the outside temperature if this


### PR DESCRIPTION
set_filter_reminder is in hours of runtime, reset to 30 days.
added info on newer omnistat stats.