### PR TITLE
raZberry binary sensor with custom ids

### DIFF
--- a/lib/raZberry.pm
+++ b/lib/raZberry.pm
@@ -1288,7 +1288,7 @@ sub new {
     #push( @{ $$self{states} }, 'on', 'off'); I'm not sure we should set the states here, since it's not a controlable item?
 
     $$self{master_object} = $object;
-    $devid = $devid . "-0-48-1";
+    $devid = $devid . "-0-48-1" unless ( $devid =~ m/-\d+-\d+/ );
     $$self{type} = "Binary Sensor";
     $$self{devid} = $devid;
     $object->register( $self, $devid, $options );


### PR DESCRIPTION
Fibaro FGK-10x transmits its on/off state with the id -0-113-6-Door-A
this change allows us to use such custom Ids for devices that behave like
binary sensors but do not use the default id (-0-48-1)