### PR TITLE
Fix for specifying a multicast interface

### DIFF
--- a/lib/AlexaBridge.pm
+++ b/lib/AlexaBridge.pm
@@ -378,7 +378,13 @@ sub _constant {
 
 sub _mcast_add {
     my ( $sock, $addr ) = @_;
-    my $ip_mreq = inet_aton( $addr ) . INADDR_ANY;
+    my $ip_mreq;
+     if (defined $::config_parms{'alexaHttpIp'}) {
+       $ip_mreq = inet_aton($::config_parms{'alexaHttpIp'});
+      } else {	
+        $ip_mreq = inet_aton('0.0.0.0');
+      }
+     $ip_mreq = inet_aton( $addr ) . $ip_mreq;
     
     setsockopt(
         $sock,


### PR DESCRIPTION
Fix for specifying a multicast interface when a specific interface is defined in the mh.private.ini with the alexaHttpIp option.