### PR TITLE
Fixed $kpl->level not returning dimming level.

### DIFF
--- a/lib/Insteon/Lighting.pm
+++ b/lib/Insteon/Lighting.pm
@@ -1198,7 +1198,9 @@ sub new {
 sub derive_link_state {
     my ( $self, $p_state ) = @_;
     if ( $self->group eq '01' ) {
-        return $self->SUPER::derive_link_state($p_state);
+	# https://github.com/hollie/misterhouse/issues/494 says SUPER isn't working
+	#return $self->SUPER::derive_link_state($p_state);
+        return return $self->Insteon::DimmableLight::derive_link_state($p_state);
     }
     else {
         return $self->Insteon::BaseObject::derive_link_state($p_state);


### PR DESCRIPTION
As per https://github.com/hollie/misterhouse/issues/494 , it wasn't
working, but calling DimmableLight::derive_link_state directly, works.