### PR TITLE
skip empty group definition in items.mht

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -1852,6 +1852,11 @@ sub read_table_A {
             next;
         }
 
+        if ( $group eq ''){
+            &::print_log("grouplist '$grouplist' contains empty group!");
+            next;
+        }
+
         if ( $name eq $group ) {
             &::print_log(
                 "mht object and group name are the same: $name  Bad idea!");


### PR DESCRIPTION
If items.mht contains an empty group definition like "GroupA|GroupB||GroupC",
misterhouse fails to start.
This simply skips over the empty definition instead of bailing out with
a compile error.