### PR TITLE
homebridge.pl: Use "http_address" alongside "http_port" to construct URLs.

### DIFF
--- a/code/common/homebridge.pl
+++ b/code/common/homebridge.pl
@@ -6,6 +6,8 @@
 #@ Thermostat control only tested with a few models.
 
 my $hb_debug = 1;
+my $http_address = $config_parms{http_address};
+$http_address = $Info{IPAddress_local} unless ($http_address);
 my $port     = $config_parms{homebridge_port};
 $port = 51826 unless ($port);
 my $name = $config_parms{homebridge_name};
@@ -58,7 +60,7 @@ if ( said $v_generate_hb_config) {
     $config_json .= add_group("thermostat");
 
     $config_json .= "\t\t}\n\t]\n}\n";
-    print_log "[Homebridge]: Writing configuration for server " . $Info{IPAddress_local} . " to $filepath...";
+    print_log "[Homebridge]: Writing configuration for server " . $http_address . " to $filepath...";
 
     #print_log $config_json;
     file_write( $filepath, $config_json );
@@ -95,14 +97,14 @@ sub add_group {
         if ( $type eq "thermostat" ) {
             $text .=
                 "\t\t\"mode_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SUB?hb_thermo_set_state%28"
               . $obj_name
               . ",%VALUE%%29\",\n";
             $text .=
                 "\t\t\"status_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SUB?hb_thermo_get_state%28"
               . $obj_name . ","
@@ -110,14 +112,14 @@ sub add_group {
               . "%29\",\n";
             $text .=
                 "\t\t\"setpoint_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SUB?hb_thermo_set_setpoint%28"
               . $obj_name
               . ",%VALUE%%29\",\n";
             $text .=
                 "\t\t\"gettemp_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SUB?hb_thermo_get_setpoint%28"
               . $obj_name
@@ -133,7 +135,7 @@ sub add_group {
                 "\t\t\""
               . $on
               . "_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SET;none?select_item="
               . $member->{object_name}
@@ -143,7 +145,7 @@ sub add_group {
                 "\t\t\""
               . $off
               . "_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SET;none?select_item="
               . $member->{object_name}
@@ -151,7 +153,7 @@ sub add_group {
               . $off . "\",\n";
             $text .=
                 "\t\t\"brightness_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SET;none?select_item="
               . $member->{object_name}
@@ -159,7 +161,7 @@ sub add_group {
               if ( $type eq "light" );
             $text .=
                 "\t\t\"speed_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SET;none?select_item="
               . $member->{object_name}
@@ -167,7 +169,7 @@ sub add_group {
               if ( $type eq "fan" );
             $text .=
                 "\t\t\"status_url\": \"http://"
-              . $Info{IPAddress_local} . ":"
+              . $http_address . ":"
               . $config_parms{http_port}
               . "/SUB?hb_status%28"
               . $obj_name . ","


### PR DESCRIPTION
For MH installations listening only on localhost, this is necessary.

Tested on my local setup.