### PR TITLE
xml_server.pl: Remove an extra blank line at the beginning of the response.

### DIFF
--- a/lib/xml_server.pl
+++ b/lib/xml_server.pl
@@ -497,7 +497,6 @@ sub xml_page {
     my $style;
     $style = qq|<?xml-stylesheet type="text/xsl" href="$xsl"?>| if $xsl;
 my $html = <<eof;
-
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 $style
 <misterhouse>


### PR DESCRIPTION
This breaks recent versions of chrome, which give the following error instead
of rendering the document:

  This page contains the following errors:
  error on line 2 at column 6: XML declaration allowed only at the start of the document