### PR TITLE
Make the self-test code more explicit so people are aware it is running

### DIFF
--- a/code/test/test_mh.pl
+++ b/code/test/test_mh.pl
@@ -16,7 +16,7 @@ if ($Startup) {
 }
 
 sub shutdown {
-    print_log "Stopping self-test, exit...";
+    print_log "Stopping self-test code in code/test/test_mh.pl, going to exit Misterhouse now...";
     run_voice_cmd("Exit Mister House");
 }
 


### PR DESCRIPTION
To avoid that people who run MisterHouse without configuration (which auto-runs the test code) get confused when MisterHouse exits as a result of the test code.
