### PR TITLE
Timer states

### DIFF
--- a/code/common/calc_eto.pl
+++ b/code/common/calc_eto.pl
@@ -976,7 +976,7 @@ sub detailSchedule {
             }
             my $t_min = int($total_time / 60);
             my $t_sec = int($total_time % 60);
-            $msg .= "[calc_eto] : Total Run Time: " .  .sprintf("%02d:%02d:%02d",$t_hours,$t_min,$t_sec) . "\n"; 
+            $msg .= "[calc_eto] : Total Run Time: " . sprintf("%02d:%02d:%02d",$t_hours,$t_min,$t_sec) . "\n"; 
         }  
     }
     return ($msg);

--- a/code/common/calc_eto.pl
+++ b/code/common/calc_eto.pl
@@ -950,12 +950,13 @@ sub detailSchedule {
     my ($stime) = @_;
     my ($times, $lengths) = $stime =~ /\[\[(.*)\],\[(.*)\]\]/;
     my $msg = "";
-    
+    my $total_time = 0;
     foreach my $time (split /,/, $times) {
         next if ($time == -1); 
         my $station_id = 1;
         $time = $time * 60; #add in seconds
         foreach my $station (split /,/, $lengths) {
+            $total_time += $station;
             my $run_hour = 0;
             if ($station > 3600) {
                 $run_hour = int($station / 3600);
@@ -966,7 +967,17 @@ sub detailSchedule {
             $msg .= "[calc_eto] : " . formatTime($time) . " : Station:" .sprintf("%2s",$station_id) . "   Run Time:" .sprintf("%02d:%02d:%02d",$run_hour,$run_min,$run_sec) . "\n" unless ($station == 0);
             $station_id++;
             $time += $run_sec + ($run_min * 60) + ($run_hour * 3600);
-        }     
+        }  
+        if ($total_time > 0) {
+            my $t_hours = 0;
+            if ($total_time > 3600) {
+                $t_hours = int($total_time / 3600);
+                $total_time = int($total_time % 3600);
+            }
+            my $t_min = int($total_time / 60);
+            my $t_sec = int($total_time % 60);
+            $msg .= "[calc_eto] : Total Run Time: " .  .sprintf("%02d:%02d:%02d",$t_hours,$t_min,$t_sec) . "\n"; 
+        }  
     }
     return ($msg);
     
@@ -1213,7 +1224,12 @@ sub main_calc_eto {
 
     }
 
-    $msg = "[calc_eto] RESULTS sunrise & sunset in minutes from midnight local time: " . $sun->{rise} . ' ' . $sun->{set};
+    my $sr_hour = int($sun->{rise} / 60);
+    my $sr_min = int($sun->{rise} % 60);
+    my $ss_hour = int($sun->{set} / 60);
+    my $ss_min = int($sun->{set} % 60);
+    
+    $msg = "[calc_eto] RESULTS sunrise & sunset from midnight local time: $sr_hour:$sr_min (" . $sun->{rise} . ") $ss_hour:$ss_min (" . $sun->{set} . ")";
     print_log $msg;
     $msg_string .= $msg . "\n";
 

--- a/code/common/calc_eto.pl
+++ b/code/common/calc_eto.pl
@@ -770,7 +770,7 @@ sub writeResults {
         #HP TODO This will determine if a 2nd, 3rd or 4th time is required.
         $times = 1 if ( ( $aET / $minRunmm ) > 1 );    #if the minium threshold is met, then run at least once.
         $times = int( max( min( $aET / $maxRunmm, 4 ), $times ) );    # int(.999999) = 0
-        print "[calc_eto] DB: times=$times aET=$aET minRunm=$minRunmm maxRunm=$maxRunmm\n";    #if ($debug);
+        print "[calc_eto] DB: times=$times aET=$aET minRunm=$minRunmm maxRunm=$maxRunmm\n" if ($debug);
         print "E:   aET[$x] = $aET (" . $aET / $maxRunmm . ") // mm/Day\n" if ($debug);
         print "E:   times = $times (max "
           . max( min( $aET / $maxRunmm, 4 ), $times ) . "/min "
@@ -853,7 +853,7 @@ sub writeResults {
         @availTimes = ($sun->{set} - sum(@runTime) / 60, $sun->{set} + 60, $sun->{set} + 120, $sun->{set} - (sum(@runTime) / 60) - 60 );         
     }
 
-    print "[times=$times, sun->{rise}=" . $sun->{rise} . " sum=" . sum(@runTime) / 60 . "]\n";    # if ($debug);
+    print "[times=$times, sun->{rise}=" . $sun->{rise} . " sum=" . sum(@runTime) / 60 . "]\n" if ($debug);
 
     for ( my $i = 0; $i < $times; $i++ ) {
         $startTime[$i] = int( $availTimes[$i] );

--- a/code/common/calc_eto.pl
+++ b/code/common/calc_eto.pl
@@ -1251,11 +1251,12 @@ sub main_calc_eto {
     #$msg = "[calc_eto] RESULTS Calculated Schedule: $rtime";
     #print_log $msg;
     #$msg_string .= $msg . "\n";
-    my ($rtime2) = detailSchedule($rtime);
+    my $rtime2 = "";
+    ($rtime2) = detailSchedule($rtime);
     foreach my $detail (split /\n/,$rtime2) {
         print_log $detail;
     }
-    $msg_string .= $msg . "\n" . $rtime2;
+    $msg_string .= $rtime2;
     if ( defined $config_parms{eto_email} ) {
         print_log "[calc_eto] Emailing results";
         net_mail_send( to => $config_parms{eto_email}, subject => "EvapoTranspiration Results for $Time_Now", text => $msg_string );

--- a/lib/Timer.pm
+++ b/lib/Timer.pm
@@ -238,7 +238,8 @@ sub set {
     return if &main::check_for_tied_filters( $self, $state );
 
     if (($self->{state_updating} == 0) and ($self->{state_enable})) {
-        &::MainLoop_pre_add_hook( \&Timer::update_state, 0, $self);
+        &::MainLoop_pre_add_hook( \&Timer::update_state, 0, $self) unless ($self->{state_updating} == 1);
+        $self->{state_updating} = 1;
     }
 
     # Set states for NEXT pass, so expired, active, etc,
@@ -261,6 +262,8 @@ sub set_from_last_pass {
         $self->{time}        = undef;
         &delete_timer_with_action($self);
         $resort_timers_with_actions = 1;
+        &::MainLoop_pre_drop_hook( \&Timer::update_state, 0, $self) unless ($self->{state_updating} == 0);
+        $self->{state_updating} = 0;
     }
 
     # Turn a timer on
@@ -300,6 +303,8 @@ sub unset {
     undef $self->{time};
     undef $self->{action};
     &delete_timer_with_action($self);
+    &::MainLoop_pre_drop_hook( \&Timer::update_state, 0, $self) unless ($self->{state_updating} == 0);
+    $self->{state_updating} = 0;
 }
 
 sub delete_old_timers {

--- a/lib/Timer.pm
+++ b/lib/Timer.pm
@@ -54,6 +54,7 @@ sub check_for_timer_actions {
     my $ref;
     while ( $ref = shift @sets_from_previous_pass ) {
         &set_from_last_pass($ref);
+#        &update_state($ref);
     }
     for $ref (&expired_timers_with_actions) {
         &run_action($ref);
@@ -110,6 +111,31 @@ sub delete_timer_with_action {
     }
 }
 
+sub update_state {
+    my ($self) = @_;
+ 
+    return unless ($::New_Second);
+    if ($self->active() ) {
+        my $repeat = 0;
+        $repeat = $self->{repeat} if (defined $self->{repeat});
+        my $seconds = $self->seconds_remaining;
+        my $hours = int($seconds / 3600);
+        my $minutes = int (($seconds % 3600) / 60);
+        my $seconds = int($seconds % 60);
+        my $state = sprintf("%d:%02d:%02d",$hours, $minutes, $seconds);
+        #&::print_log("****** state=$state");
+        $state .= ",$repeat" if ($repeat);
+        $self->{state} = $state;
+        $self->{set_time} = $::Time;
+    } else {
+        unless ($self->{state} eq "inactive") {
+            $self->{state} = "inactive" ;
+            $self->{set_time} = $::Time;
+        }
+    }
+   
+}
+
 =item C<new>
 
 Used to create the object.
@@ -122,6 +148,17 @@ sub new {
 
     # Not sure why this gives an error without || Timer
     bless $self, $class || 'Timer';
+    # $id isn't actually used? Going to use that as a flag to enable/disable state setting
+    $self->{state_enable} = 1;
+    $self->{state_enable} = $::config_parms{enable_timer_state_updates} if (defined $::config_parms{enable_timer_state_updates});
+    $self->{state_enable} = $id if (defined $id);
+    if ($self->{state_enable}) {
+        $self->{state} = "inactive";
+    } else {
+        $self->{state} = undef;  #restore the previous default behavior
+    }
+    $self->{state_updating} = 0; #&::MainLoop_pre_add_hook doesn't seem to be available yet, so add it to the set
+
     return $self;
 }
 
@@ -178,6 +215,11 @@ sub state_log {
     return @{ $$self{state_log} } if $$self{state_log};
 }
 
+sub get_idle_time {
+    return undef unless $_[0]->{set_time};
+    return $main::Time - $_[0]->{set_time};
+}
+
 =item C<set($period, $action, $cycles)>
 
 $period is the timer period in seconds
@@ -194,6 +236,10 @@ sub set {
 
     #   print "db1 $main::Time_Date running set s=$self s=$state a=$action t=$self->{text} c=@c\n";
     return if &main::check_for_tied_filters( $self, $state );
+
+    if (($self->{state_updating} == 0) and ($self->{state_enable})) {
+        &::MainLoop_pre_add_hook( \&Timer::update_state, 0, $self);
+    }
 
     # Set states for NEXT pass, so expired, active, etc,
     # checks are consistent for one pass.


### PR DESCRIPTION
Looks like the calc_eto update got included. A change to Timer so that the states are updated when a timer is active. Displays on IA7 instead of just showing 'undefined'

  Old behavior can be restored with mh.ini parameter: enable_timer_state_updates = 0