### PR TITLE
Fix unescaped braces in issue #774

### DIFF
--- a/web/bin/code_select.pl
+++ b/web/bin/code_select.pl
@@ -73,7 +73,7 @@ activate properly.|;
             $category =~ s/\s+$//;    # Drop trailing whitespace
 
             # Ignore $config_parm{$xyz} entries
-            while ( $line =~ /config_parms{([^\$]+)}/g ) {
+            while ( $line =~ /config_parms\{([^\$]+)\}/g ) {
                 $file_parms{$1}++ unless $standard_parms{$1};
             }
         }

--- a/web/bin/code_unselect.pl
+++ b/web/bin/code_unselect.pl
@@ -89,7 +89,7 @@ The following fils are all the code files in you code_dir list:  $config_parms{c
             $category =~ s/\s+$//;    # Drop trailing whitespace
 
             # Ignore $config_parm{$xyz} entries
-            while ( $line =~ /config_parms{([^\$]+)}/g ) {
+            while ( $line =~ /config_parms\{([^\$]+)\}/g ) {
                 $file_parms{$1}++ unless $standard_parms{$1};
             }
         }


### PR DESCRIPTION
Failed on Perl 5.26.1, Ubuntu 18.04.   