### PR TITLE
fix http redirect with nginx proxy

### DIFF
--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -2318,7 +2318,7 @@ sub http_redirect {
  $html_head .= "Server: MisterHouse\r\n";
  $html_head .= "Location: $url\r\n";
  $html_head .= "Content-Length: 0\r\n";
- $html_head .= "Connection: close\r\n " if &http_close_socket;
+ $html_head .= "Connection: close\r\n" if &http_close_socket;
  $html_head .= "Cache-Control: no-cache\r\n";
  $html_head .= "\r\n";
 


### PR DESCRIPTION
If misterhouse is run behind nginx webserver the superfluous space
in line 2321 causes broken redirects (Location header is changed to
"Location: $url Cache-Control: no-cache" instead of only
"Location: $url"