### PR TITLE
prevent warning with alexa/echo

### DIFF
--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -375,7 +375,11 @@ sub http_process_request {
 	# For this reason we use a regular expresion here instead of
 	# checking for "application/json" using the "eq" operator.
 	#
-        } elsif ($Http{'Content-Type'} =~ m%^application/json%i && $HTTP_BODY =~ /^\{/) {
+    # alex/echo sends
+    # Content-type: application/x-www-form-urlencoded
+    # with a json body
+    #
+        } elsif ($Http{'Content-Type'} =~ m%^application/(json\|x-www-form-urlencoded)%i && $HTTP_BODY =~ /^\{/) {
              print "[http_server.pl]: posting json data\n" if $main::Debug{http};
         } else {
             &main::print_log("[http_server.pl]: Warning, invalid argument string detected ($buf) ($Http{'Content-Type'}) ($HTTP_BODY)\n");


### PR DESCRIPTION
If AlexaBidge.pl is used http_server.pl logs a warning when the echo
reqeusts to change the state of a light: "[http_server.pl]: Warning,
invalid argument string detected (...)" this change prevents the warning
since it is a valid request.