### PR TITLE
Add beep() method to Insteon::DimmableLight

### DIFF
--- a/lib/Insteon/BaseInsteon.pm
+++ b/lib/Insteon/BaseInsteon.pm
@@ -1388,6 +1388,7 @@ our %message_types = (
     poke_internal         => 0x2d,
     extended_set_get      => 0x2e,
     read_write_aldb       => 0x2f,
+    beep                  => 0x30,
     imeter_reset          => 0x80,
     imeter_query          => 0x82,
 );

--- a/lib/Insteon/Lighting.pm
+++ b/lib/Insteon/Lighting.pm
@@ -423,6 +423,24 @@ sub get_voice_cmds {
 
 =back
 
+=item C<beep()>
+
+Beep the device;
+
+=cut
+
+sub beep {
+    my ( $self ) = @_;
+    my $name = $self->get_object_name;
+
+    ::print_log( "[Insteon::DimmableLight] Beeping $name." )
+          if $self->debuglevel( 1, 'insteon' );
+
+    my $message = new Insteon::InsteonMessage( 'insteon_send', $self, 'beep', 0x00 );
+    $self->_send_cmd($message);
+}
+
+
 =head2 AUTHOR
 
 Gregg Limming 


### PR DESCRIPTION
Add beep() method to Insteon::DimableLight.  Triggers the switch to beep briefly.  Can be used for auditory feedback (e.g. acknowledge a special switch sequence), to identify/locate a device, etc.