### PR TITLE
fix regulare expression to check content type

### DIFF
--- a/lib/http_server.pl
+++ b/lib/http_server.pl
@@ -379,7 +379,7 @@ sub http_process_request {
     # Content-type: application/x-www-form-urlencoded
     # with a json body
     #
-        } elsif ($Http{'Content-Type'} =~ m%^application/(json\|x-www-form-urlencoded)%i && $HTTP_BODY =~ /^\{/) {
+        } elsif ($Http{'Content-Type'} =~ m%^application/(json|x-www-form-urlencoded)%i && $HTTP_BODY =~ /^\{/) {
              print "[http_server.pl]: posting json data\n" if $main::Debug{http};
         } else {
             &main::print_log("[http_server.pl]: Warning, invalid argument string detected ($buf) ($Http{'Content-Type'}) ($HTTP_BODY)\n");


### PR DESCRIPTION
This fixes the previous commit, which makes the problem of false
warnings actually worse. I'm sorry  for the inconvenience, i really
don't know how i could not notice this before creating the last pull
request.