### PR TITLE
bin: correct @INC in stand-alone Perl programs so lib/fallback is last

### DIFF
--- a/bin/alpha_page
+++ b/bin/alpha_page
@@ -31,7 +31,9 @@ BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
     $Pgm_Root = "$Pgm_Path/..";
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
+
 }
 
 use Getopt::Long;

--- a/bin/get_earthquakes
+++ b/bin/get_earthquakes
@@ -55,7 +55,8 @@ eof
 }
 
 BEGIN {
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }                                # Use BEGIN eval to keep perl2exe happy
 require 'handy_utilities.pl';    # For read_mh_opts funcion
 

--- a/bin/get_email
+++ b/bin/get_email
@@ -31,7 +31,8 @@ BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
     $Pgm_Root = "$Pgm_Path/..";
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use Getopt::Long;

--- a/bin/get_tcp
+++ b/bin/get_tcp
@@ -11,7 +11,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my ( %config_parms, %parms );

--- a/bin/get_tv_grid
+++ b/bin/get_tv_grid
@@ -45,7 +45,8 @@ BEGIN {
     ($Version) = q$Revision$ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 require "RedirAgent.pm";

--- a/bin/get_tv_grid_ge
+++ b/bin/get_tv_grid_ge
@@ -40,7 +40,8 @@ BEGIN {
     ($Version) = q$Revision$ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 my %parms;
 use Getopt::Long;

--- a/bin/get_tv_grid_xmltv
+++ b/bin/get_tv_grid_xmltv
@@ -57,7 +57,8 @@ BEGIN {
     ($Version) = q$Revision$ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # So perl2exe works
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";    # So perl2exe works
 }
 
 use XMLTV::Version '$Id$ ';

--- a/bin/get_tv_info
+++ b/bin/get_tv_info
@@ -26,7 +26,8 @@ BEGIN {
 
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my %parms;

--- a/bin/get_tv_info_ge
+++ b/bin/get_tv_info_ge
@@ -23,7 +23,8 @@ BEGIN {
 
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my %parms;

--- a/bin/get_url
+++ b/bin/get_url
@@ -9,7 +9,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback' ";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my ( %config_parms, %parms );

--- a/bin/get_weather
+++ b/bin/get_weather
@@ -81,9 +81,9 @@ $opt_v++ if $parms{v};    # Geo::Weather looks at this
 my $caller = caller;
 my $return_flag = ( $caller and $caller ne 'main' ) ? 1 : 0;
 
-#use my_lib "$Pgm_Path/../lib/site", "$Pgm_Path/../lib/fallback"; # See note in lib/mh_perl2exe.pl for lib -> my_lib explaination
 BEGIN {
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }                         # Use BEGIN eval to keep perl2exe happy
 
 require 'handy_utilities.pl';    # For read_mh_opts funcion

--- a/bin/get_weather_ca
+++ b/bin/get_weather_ca
@@ -75,9 +75,9 @@ use vars qw(%Weather @Weather_Forecast);
 my $caller = caller;
 my $return_flag = ( $caller and $caller ne 'main' ) ? 1 : 0;
 
-#use my_lib "$Pgm_Path/../lib/site", "$Pgm_Path/../lib/fallback"; # See note in lib/mh_perl2exe.pl for lib -> my_lib explaination
 BEGIN {
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }    # Use BEGIN eval to keep perl2exe happy
 
 require 'handy_utilities.pl';    # For read_mh_opts funcion

--- a/bin/ical2vsdb
+++ b/bin/ical2vsdb
@@ -30,7 +30,8 @@ use strict;
 ##    Sometimes icals are unchanged, but the order is different when downloading. Add option to sort the ical to ensure
 ##    Data hasn't changed even if the order did. Added option sort_before_md5 = 1 to enable globally or to the specific ical
 
-use lib '../lib', '../lib/site', '../lib/fallback';
+use lib '../lib', '../lib/site';
+push @INC, "../lib/fallback";
 use iCal::Parser;
 use DateTime;
 use Digest::MD5 qw(md5 md5_hex);

--- a/bin/ical_load
+++ b/bin/ical_load
@@ -27,7 +27,8 @@ BEGIN {
     ($Version) = q$Revision$ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use Getopt::Long;

--- a/bin/net_ftp
+++ b/bin/net_ftp
@@ -7,7 +7,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my %parms;

--- a/bin/outlook_read
+++ b/bin/outlook_read
@@ -40,7 +40,8 @@ BEGIN {
     ($Version) = q$Revision$ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use Getopt::Long;

--- a/bin/pocketsphinx
+++ b/bin/pocketsphinx
@@ -39,7 +39,8 @@ BEGIN {
     ($Version) = q$Revision: 1084 $ =~ /: (\S+)/;    # Note: revision number is auto-updated by cvs
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use Getopt::Long;

--- a/bin/read_email
+++ b/bin/read_email
@@ -7,7 +7,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my %parms;

--- a/bin/report_weblog
+++ b/bin/report_weblog
@@ -32,7 +32,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my %parms;

--- a/bin/send_email
+++ b/bin/send_email
@@ -7,7 +7,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 my %parms;

--- a/bin/set_clock
+++ b/bin/set_clock
@@ -89,7 +89,8 @@ print "Requesting the time from $parms{server} using $parms{method} method\n";
 #use my_lib "$Pgm_Path/../lib";      # See note in lib/mh_perl2exe.pl for lib -> my_lib explaination
 #use my_lib "$Pgm_Path/../lib/site"; # See note in lib/mh_perl2exe.pl for lib -> my_lib explaination
 BEGIN {
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }    # Use BEGIN eval to keep perl2exe happy
 
 my $time_record;

--- a/bin/set_password
+++ b/bin/set_password
@@ -90,7 +90,8 @@ else {
 my ( %config_parms, %passwords );
 
 sub setup {
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
     require 'handy_utilities.pl';                                  # For read_mh_opts funcion
     &main::read_mh_opts( \%config_parms, $Pgm_Path );
 

--- a/bin/snpp_page
+++ b/bin/snpp_page
@@ -43,7 +43,8 @@ BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
     $Pgm_Root = "$Pgm_Path/..";
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 #--------------------------------------------------------------------------------

--- a/bin/sun_time
+++ b/bin/sun_time
@@ -32,7 +32,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use Getopt::Long;

--- a/bin/test_x10
+++ b/bin/test_x10
@@ -11,7 +11,8 @@
 #   perl test_x10 CM17 COM1 B 2
 
 use strict;
-use lib '../lib', '../lib/site', '../lib/fallback';
+use lib '../lib', '../lib/site';
+push @INC, '$Pgm_Path/../lib/fallback';
 
 my ( $device, $port, $house, $unit, $interface, %config_parms );
 

--- a/bin/update_docs
+++ b/bin/update_docs
@@ -53,7 +53,8 @@ my ( $Pgm_Path, $Pgm_Name );
 BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.*)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # So perl2exe works
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use strict;

--- a/bin/vv_tts.pl
+++ b/bin/vv_tts.pl
@@ -24,7 +24,8 @@ BEGIN {
     ( $Pgm_Path, $Pgm_Name ) = $0 =~ /(.*)[\\\/](.+)\.?/;
     ($Pgm_Name) = $0 =~ /([^.]+)/, $Pgm_Path = '.' unless $Pgm_Name;
     $Pgm_Root = "$Pgm_Path/..";
-    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site', '$Pgm_Path/../lib/fallback'";    # Use BEGIN eval to keep perl2exe happy
+    eval "use lib '$Pgm_Path/../lib', '$Pgm_Path/../lib/site';";    # Use BEGIN eval to keep perl2exe happy
+    eval "push \@INC, '$Pgm_Path/../lib/fallback';";
 }
 
 use Getopt::Long;


### PR DESCRIPTION
This should move lib/fallback to the end of @INC in the stand-alone bin programs. I can't test them all to make sure they're working, as I don't have the environment some of them are looking for (not running under Windows, don't have specific device X, etc.). Verifying that all this code still works, however, is a larger project. I have verified that none of them have syntax errors except for missing modules in a few cases (Win32::OLE, etc.). I've also spot checked them in execution to make sure lib/fallback appears at the end where it belongs, and all the ones I checked were fine.