### PR TITLE
Added MQTT LWT and Wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
-## [Unreleased](https://github.com/hollie/misterhouse/tree/HEAD)
+## [5.0](https://github.com/hollie/misterhouse/tree/5.0) (2017-10-31)
 
-[Full Changelog](https://github.com/hollie/misterhouse/compare/v4.2...HEAD)
+[Full Changelog](https://github.com/hollie/misterhouse/compare/v4.2...v5.0)
+
+**Fixed bugs:**
+
+- "Keys on Scalar" Syntax in json\_server.pl Causes Fatal Error in Later Perl Versions [\#737](https://github.com/hollie/misterhouse/issues/737)
 
 **Closed issues:**
 
@@ -20,6 +24,9 @@
 
 **Merged pull requests:**
 
+- removed nanolead poll queue, updated MH5 whatsnew page [\#739](https://github.com/hollie/misterhouse/pull/739) ([hplato](https://github.com/hplato))
+- Fix lines in json\_server.pl that use deprecated "keys on scalar" syntax [\#738](https://github.com/hollie/misterhouse/pull/738) ([JaredF](https://github.com/JaredF))
+-  IA7 v1.6.700 - whats new, bugfixes [\#736](https://github.com/hollie/misterhouse/pull/736) ([hplato](https://github.com/hplato))
 - Ia7 [\#735](https://github.com/hollie/misterhouse/pull/735) ([hplato](https://github.com/hplato))
 - Ia7 v1.6.540 / mh5.0 [\#734](https://github.com/hollie/misterhouse/pull/734) ([hplato](https://github.com/hplato))
 - Razberry [\#731](https://github.com/hollie/misterhouse/pull/731) ([hplato](https://github.com/hplato))

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-unstable
+5.0

--- a/docs/download.pod
+++ b/docs/download.pod
@@ -10,7 +10,7 @@ modify the code/common/mh_release.pl file to search the new format!!
 
 =head1 Current Stable
 
-B<Version 4.2> - released on 03/08/2017
+B<Version 5.0> - released on 10/31/2017
 
 =over
 
@@ -28,7 +28,7 @@ A large (30MB) zip of optional files (mainly sound files) is here: L<http://mist
 
 =head1 Previous Stable
 
-B<Version 4.1> - released on 02/28/2016 
+B<Version 4.2> - released on 03/08/2017
 
 =over
 
@@ -37,7 +37,7 @@ B<Version 4.1> - released on 02/28/2016
 =begin HTML
 
 <strong>
-<a href='https://api.github.com/repos/hollie/misterhouse/zipball/v3.0' target='_blank'>https://api.github.com/repos/hollie/misterhouse/zipball/v3.0</a>
+<a href='https://api.github.com/repos/hollie/misterhouse/zipball/v3.0' target='_blank'>https://api.github.com/repos/hollie/misterhouse/zipball/v4.2</a>
 </strong>
 
 =end HTML
@@ -68,6 +68,6 @@ Subscribe to the Misterhouse release announcement mailing list here:  L<http://l
 
 Or join the Misterhouse community mailing list here: L<http://lists.sourceforge.net/mailman/listinfo/misterhouse-users>
 
-Last modified 03/02/2013 11:03:55
+Last modified 10/31/2017 
 
 =cut


### PR DESCRIPTION
This pull adds;
# MQTT wildcards.
You can define MH devices like;
`MQTT_DEVICE, MQTT_test_wildcard, , mqtt_1, tele/+/LWT` 
then this device will receive all messages from topics that match the wildcard, `$MQTT_test_wildcard->{set_by_topic}` is set to the name of the topic that sent the original message and `$MQTT_test_wildcard->{state}` is set to the payload of the message. It supports both single wildcards like `stat/#` and multilevel like `+/mydevice/+`.
# LWT
When MH connects to the MQTT broker it adds the LWT topic and message from mh.ini settings
```
mqtt_LWT_topic=tele/Misterhouse/LWT
mqtt_LWT_payload=offine
```
If it subsequently goes down the broker publishes this message. You should also publish an online message to `tele/Misterhouse/LWT` when MH starts.