### PR TITLE
Added support for Insteon outlet

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -329,6 +329,13 @@ sub read_table_A {
         $other = join ', ', ( map { "'$_'" } @other );             # Quote data
         $object = "Insteon::FanLinc(\'$address\', $other)";
     }
+    elsif ( $type eq "INSTEON_OUTLETLINC" ) {
+	#<,INSTEON_OUTLETLINC,Address,Name,Groups>#
+        require Insteon::Lighting;
+        ( $address, $name, $grouplist, @other ) = @item_info;
+        $other = join ', ', ( map { "'$_'" } @other );             # Quote data
+        $object = "Insteon::OutletLinc(\'$address\', $other)";
+    }
     elsif ( $type eq "INSTEON_ICONTROLLER" ) {
 	#<,SCENE_MEMBER,MemberName,LinkName,OnLevel,RampRate>#
         require Insteon::BaseInsteon;


### PR DESCRIPTION
Added support for the Insteon outlet device 2663-222. Code in Insteon/Lighting.pm and record processing added to read_table_A.pl.

This device is a little different as it takes commands to group 1 and group 2. I modelled the code off the fanlinc device code, although I am pretty sure that code doesn't work. I don't have a fanlinc device so I didn't want to muck with it.