### PR TITLE
Customised print_log

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -4498,7 +4498,28 @@ sub play {
 
 }
 
+
+# 14-jan-2021 new print_log added and old print_log renamed print_log_simple 
+# see https://github.com/hollie/misterhouse/wiki/Developer-help#logging
+
 sub print_log {
+	my ($message,$severity,$source) = @_;
+	if (defined(&print_log_private)) {
+			print_log_private($message,$severity,$source);
+			return;
+	}
+	if (defined($severity)) {
+		$message .=  " " . $severity . ":";
+	}
+	if (defined($source)) {
+		$message .= " [" . $source . "] ";
+	}
+	print_log_simple($message);
+}
+
+
+# renamed from print_log
+sub print_log_simple {
 
     #   my ($data) = @_;
     my $data = "@_";

--- a/code/examples/print_log_private.pl
+++ b/code/examples/print_log_private.pl
@@ -1,0 +1,68 @@
+#-----------------------------------------------------------------------
+# example subroutine to be substituted in print_log instead of just
+# printing the message to file
+# it takes 3 parameters;
+# message - the message
+# severity - one of EMERGENCY, ALERT, CRITICAL, ERROR, WARNING, NOTICE, 
+#            INFORMATIONAL, DEBUG or NONE 
+#            if NONE is set, it just returns and not do anything
+# source -  where the message originated, e.g. my_subroutine
+# Edit this to enable MisterHouse to email/sms/twitter certain severities of message
+# Author:   Giles Godart-Brown 14-jan-2020
+#-----------------------------------------------------------------------
+
+sub print_log_private {
+	my ($message,$severity,$source) = @_;
+	
+	# WARNING	WARNING		WARNING		WARNING		WARNING		WARNING
+	# DO NOT CALL print_log FROM HERE, it will LOOP, use print_log_simple
+	
+	# dont do anything if severity set to NONE
+	if ($severity eq "NONE" ) {
+		return;
+	}
+	
+	# create formatted message to print/email/sms
+	my $local_message = $message;	
+	if (defined($severity)) {
+		$local_message = $severity . " " . $local_message;
+	}
+	if (defined($source)) {
+		$local_message = "[print_log_private-" . $source . "] ".  $local_message;
+	} else {
+		$local_message = "[print_log_private] ".  $local_message;
+	}
+	
+	# decide what to do based on severity
+	
+	if ($severity eq "EMERGENCY" ) {			# code to manage emergency messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "ALERT" ) {			# code to manage alert messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "CRITICAL" ) {		# code to manage critical messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "ERROR" ) {			# code to manage error messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "WARNING" ) {			# code to manage warning messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "NOTICE" ) {			# code to manage notice messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "INFORMATIONAL" ) {	# code to manage info messages goes here
+		print_log_simple($local_message);
+		return;
+	} elsif ($severity eq "DEBUG" ) {			# code to manage debug messages goes here
+		print_log_simple($local_message);
+		return;
+	}
+	
+    print_log_simple("[print_log_private] WARNING invalid severity $severity");
+    print_log_simple($local_message);
+    return;   
+	
+}


### PR DESCRIPTION
This requests renames print_log to print_log_simple and creates a new version of print_log that;
1) adds optional parameters severity and source
2) if the implementation has a print_log_private subroutine, this is called instead of print_log_simple allowing the implementation to route messages e.g. based on severity. Otherwise print_log_simple is called with the message concatenated with severity and source. Message has to be first to preserve print_log("logfile=myfile.log ...") functionality.
Backwards compatibility tested.
Docs updated at https://github.com/hollie/misterhouse/wiki/Developer-help#logging and https://github.com/hollie/misterhouse/wiki/Functions#print_log-print_log_simple-print_msg-print_speaklog (note you may need to scroll here as there appears to be a bug in some browsers).
An example print_log_private is provided in code/examples