### PR TITLE
Mqtt items and discovery

### DIFF
--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -64,7 +64,7 @@ Usage:
             my $state = ('on' eq state $M2_Temp) ? 'off' : 'on';
             set $M2_Temp $state;
             my $remark = "M2 Light set to $state";
-            print_log "$remark";
+            &print_log( "$remark" );
         }
 
     CLI generation of a command to the CR_Temp
@@ -184,23 +184,38 @@ use IO::Socket::INET;
 
 use Time::HiRes;
 
-#use JSON qw( decode_json );     #
-
 use Data::Dumper;
 
 eval "use bytes";    # Not on all installs, so eval to avoid errors
 
 # Need to share this with the outside world
-my $buf    = '';
 my $msg_id = 1;
 
 my %MQTT_Data;
 
-#$main::Debug{mqtt} = 1;
+# $main::Debug{mqtt} = 0;
 
 # ------------------------------------------------------------------------------
 sub dump() {
     &main::print_log( "*** mqtt Dumper (MQTT_Data):\n" . Dumper( \%MQTT_Data ) . "***" );
+}
+
+sub log {
+    my ($self, $str) = @_;
+    &main::print_log( 'MQTT: '. $str );
+}
+
+sub debug {
+    my( $self, $level, $str ) = @_;
+    if( $main::Debug{mqtt} >= $level ) {
+	$level = 'D' if $level == 0;
+	&main::print_log( "MQTT D$level: $str" );
+    }
+}
+
+sub error {
+    my ($self, $str, $level ) = @_;
+    &main::print_log( "MQTT ERROR: $str" );
 }
 
 # ------------------------------------------------------------------------------
@@ -211,20 +226,21 @@ sub dump() {
 sub mqtt_connect() {
     my ($self) = @_;
 
-    &main::print_log("*** mqtt mqtt_connect Socket ($$self{host}:$$self{port},$$self{keep_alive_timer}) ") if ( $main::Debug{mqtt} );
+    $self->debug( 1, "mqtt_connect Socket ($$self{host}:$$self{port},$$self{keep_alive_timer}) ");
 
     ### 1) open a socket (host, port and keepalive
     my $socket = IO::Socket::INET->new(
         PeerAddr => $self->{host} . ':' . $self->{port},
-        Timeout  => $self->{keep_alive_timer},
+        Timeout => 2,
+        # Timeout  => $self->{keep_alive_timer},
     );
 
     # Can't use this at this time
     # $socket = new main::Socket_Item(undef, undef, "$host:$port", $instance);
 
     if ( !defined($socket) ) {
-        if ( $$self{recon_timer}->inactive ) {
-            ::print_log("*** mqtt connection for $$self{instance} failed, I will try to reconnect in 20 seconds");
+        if ($$self{recon_timer}->inactive) {
+            $self->debug( 1, "mqtt connection for $$self{instance} failed, I will try to reconnect in 20 seconds");
             my $inst = $$self{instance};
             $$self{recon_timer}->set( 20, sub { $MQTT_Data{$inst}{self}->mqtt_connect() } );
             return;
@@ -234,6 +250,7 @@ sub mqtt_connect() {
     $self->{socket}            = $socket;
     $self->{got_ping_response} = 1;
     $self->{next_ping}         = $self->{keep_alive_timer};
+    $self->{buf}	       = '';
 
     # --------------------------------------------------------------------------
     ### 2) Send MQTT_CONNECT
@@ -241,27 +258,25 @@ sub mqtt_connect() {
     $self->send_mqtt_msg(
         message_type     => MQTT_CONNECT,
         keep_alive_timer => $self->{keep_alive_timer},
-        user_name        => $self->{user_name},
-        password         => $self->{password},
-        will_topic       => $::config_parms{mqtt_LWT_topic},
-        will_message     => $::config_parms{mqtt_LWT_payload}
+	user_name	 => $self->{user_name},
+	password	 => $self->{password},
+	will_topic	 => $::config_parms{mqtt_LWT_topic},
+	will_message	 => $::config_parms{mqtt_LWT_payload}
     );
 
     ### 3) Check for ACK or fail
-    &main::print_log( "*** mqtt Socket check ($$self{keep_alive_timer}) [ $! ]: " . ( $self->isConnected() ? "Connected" : "Failed" ) )
-      if ( $main::Debug{mqtt} );
+    $self->debug( 1, "Socket check ($$self{keep_alive_timer}) [ $! ]: " . ( $self->isConnected() ? "Connected" : "Failed" ) );
 
-    my $msg = read_mqtt_msg_timeout( $self, $buf );
+    my $msg = $self->read_mqtt_msg_timeout();
     if ( !$msg ) {
-        &main::print_log("XXX mqtt $$self{instance} No ConnAck ");
+        $self->error("mqtt $$self{instance} No ConnAck ");
 
         #exit 1;
         return;
     }
 
     # We should actually get a SubAck but who is checking (yes, I know I should)
-    &main::print_log( "*** mqtt $$self{instance} Received: " . $msg->string )
-      if ( $main::Debug{mqtt} );
+    $self->debug( 1, "$$self{instance} Received: " . $msg->string );
 
     ### 4) Send a subscribe '#' (we'll have many of these, one for each device)
     ###    I don't know if this is a good idea or not but that's what I intend to do for now
@@ -272,8 +287,10 @@ sub mqtt_connect() {
     );
 
     ### 5) Check for ACK or fail
-    $msg = $self->read_mqtt_msg_timeout($buf)
-      or &main::print_log( "*** mqtt $$self{instance} Received: " . "No SubAck" );
+    $msg = $self->read_mqtt_msg_timeout();
+    if( !$msg ) {
+        $self->log( "$$self{instance} Received: " . "No SubAck" );
+    }
     if ( $main::Debug{mqtt} ) {
         my $s =
           defined( $$msg{string} )
@@ -282,12 +299,11 @@ sub mqtt_connect() {
         ###
         ### IF we're not getting $$msg{string} then what are we getting ?
         ###
-        &main::print_log( "*** mqtt $$self{instance} Sub 1 Received: " . "$s" );    # @FIXME: Use of uninitialized value
+        $self->log( "$$self{instance} Sub 1 Received: " . "$s" );    # @FIXME: Use of uninitialized value
     }
 
     ### 6) check for data
-    &main::print_log("*** mqtt $$self{instance} Initializing MQTT connection ...")
-      if ( $main::Debug{mqtt} );
+    $self->debug( 1, "$$self{instance} Initializing MQTT connection ...");
 }
 
 # ------------------------------------------------------------------------------
@@ -297,7 +313,7 @@ sub mqtt_connect() {
 
 sub isConnected {
     my ($self) = @_;
-    unless ( defined( $$self{socket} ) ) { return 0 }
+    unless ( defined($$self{socket} ) ) { return 0 }
     return $$self{socket}->connected;
 }
 
@@ -308,7 +324,7 @@ sub isConnected {
 
 sub isNotConnected {
     my ($self) = @_;
-    unless ( defined( $$self{socket} ) ) { return 1 }
+    unless ( defined($$self{socket} ) ) { return 1 }
     return !$$self{socket}->connected;
 }
 
@@ -322,9 +338,21 @@ sub isNotConnected {
 
 sub new {
     my ( $class, $instance, $host, $port, $topic, $user, $password, $keep_alive_timer ) = @_;
+    my $self;
 
-    my $self = {};
+    if( !defined( $main::Debug{mqtt} ) ) {
+	$main::Debug{mqtt} = 0;
+    }
 
+    # 20-12-2020 edit to enable MH to monitor all mqtt topics especially for wildcards e.g. LWT
+    $topic		= $topic    || $::config_parms{mqtt_topic}	|| '#';
+    $host		= $host	    || $::config_parms{mqtt_host}	|| '127.0.0.1';
+    $port		= $port	    || $::config_parms{mqtt_port}	|| 1883;
+    $user		= $user	    || $::config_parms{mqtt_username}	|| '';
+    $password		= $password || $::config_parms{mqtt_password}	|| '';
+
+    $keep_alive_timer = 120 if !defined( $keep_alive_timer );    # retain a provided 0
+   
     # If we have already created a socket and have an existing instance then
     # return the existing instance. MQTT doesn't like having 2 sockets to the
     # same server and will close the old socket.
@@ -349,15 +377,17 @@ sub new {
                     );
 
                     ### 5) Check for ACK or fail
-                    $buf = '';
-                    my $msg = read_mqtt_msg( $self, $buf )
-                      or &main::print_log( "*** mqtt $$self{instance} Received: " . "No SubAck" );
-                    &main::print_log( "*** mqtt $inst Sub 2 Received: " . $msg->string )
-                      if ( $main::Debug{mqtt} );
+                    $self->{buf} = '';
+		    my $msg = $self->read_mqtt_msg();
+		    if( !$msg ) {
+			$self->log( "$$self{instance} Received: " . "No SubAck" );
+		    } else {
+			$self->debug( 1, "$inst Sub 2 Received: " . $msg->string );
+		    }
                 }
 
                 # This is the little messages that appear when MH starts
-                &main::print_log("*** Reusing $inst (instead of $instance) on $host:$port $topic");
+                &mqtt::log( undef, "Reusing $inst (instead of $instance) on $host:$port $topic");
 
                 ###
                 ### Ran into an issue doing it this way, it renames the object to the last
@@ -370,74 +400,68 @@ sub new {
         }
     }
 
-    # This is the little messages that appear when MH starts
-    &main::print_log("*** Creating $instance on $host:$port $topic");
+    $self = {};
 
-    $$self{state}     = 'off';
-    $$self{said}      = '';
-    $$self{state_now} = 'off';
+    $$self{state}		= 'off';
+    $$self{said}		= '';
+    $$self{state_now}		= 'off';
 
-    @{ $$self{command_stack} } = ();
+    $self->{command_stack}	= [];
+    $self->{retained_topics}	= {};
 
-    $$self{instance}    = $instance;
-    $$self{recon_timer} = ::Timer::new();
-    $$self{host}        = "$host" || "127.0.0.1";
-    $$self{port}        = $port   || 1883;
+    $$self{instance}		= $instance;
+    $$self{recon_timer}		= ::Timer::new();
+    $$self{host}		= $host;
+    $$self{port}		= $port;
+    $$self{topic}		= $topic;
+    $$self{user_name}		= $user;
+    $$self{password}		= $password;
+    $$self{keep_alive_timer}	= $keep_alive_timer;
 
-    # Use the wildcard here, not in the mqtt_Item
-    #$$self{topic} = "$topic" || "home/ha/#";
-    # 20-12-2020 edit to enable MH to monitor all mqtt topics especially for wildcards e.g. LWT
-    $$self{topic} = "$topic" || "#";
-
-    # Currently not used
-    $$self{user_name} = "$user" || "";
-
-    # Currently not used
-    $$self{password}         = "$password"       || "";
-    $$self{keep_alive_timer} = $keep_alive_timer || 120;
-
-    #
-    $$self{next_ping}         = 0;
-    $$self{got_ping_response} = 1;    # We really don't use this (yet)
+    $$self{next_ping}		= 0;
+    $$self{got_ping_response}	= 1; 
 
     bless $self, $class;
+
+    # This is the little messages that appear when MH starts
+    $self->log("Creating $instance on $host:$port $topic");
 
     $self->set_states( "off", "on" );
 
     $MQTT_Data{$instance}{self} = $self;
 
-    if ( $main::Debug{mqtt} ) {
-        &main::print_log("*** Opening MQTT ($instance) connection to $$self{host}/$$self{port}/$$self{topic}");
-        &main::print_log("*** Host       = $$self{host}");
-        &main::print_log("*** Port       = $$self{port}");
-        &main::print_log("*** Topic      = $$self{topic}");
-        &main::print_log("*** User       = $$self{user_name}");
-        &main::print_log("*** Password   = $$self{password}");
-        &main::print_log("*** Keep Alive = $$self{keep_alive_timer}");
-    }
+    $self->debug(1, "Opening MQTT ($instance) connection to $$self{host}/$$self{port}/$$self{topic}");
+    $self->debug(1, "    Host       = $$self{host}");
+    $self->debug(1, "    Port       = $$self{port}");
+    $self->debug(1, "    Topic      = $$self{topic}");
+    $self->debug(1, "    User       = $$self{user_name}");
+    $self->debug(1, "    Password   = $$self{password}");
+    $self->debug(1, "    Keep Alive = $$self{keep_alive_timer}");
+
     ### ------------------------------------------------------------------------
     $self->mqtt_connect();
 
-    unless ($self) {
-        &main::print_log("\n***\n*** Hmm, this is not good!, can't find myself\n***\n");
-        return;
+    unless ($self) { 
+    	$self->error("\n***\n*** Hmm, this is not good!, can't find myself\n***\n");
+    	return;
     }
 
     # Hey what happens when we fail ?
     #$MQTT_Data{$instance}{self} = $self;
     if ( 1 == scalar( keys %MQTT_Data ) ) {    # Add hooks on first call only
-        &main::print_log("*** mqtt added MQTT check_for_data ...");
+        $self->log("added MQTT check_for_data ...");
         &::MainLoop_pre_add_hook( \&mqtt::check_for_data, 1 );
     }
     else {
-        #&main::print_log ("*** mqtt already added MQTT poll ..." . scalar(keys %MQTT_Data) );
-        #&main::print_log ("*** mqtt already added MQTT poll ... but that's okay" );
+        #$self->log("already added MQTT poll ..." . scalar(keys %MQTT_Data) );
+        #$self->log("already added MQTT poll ... but that's okay" );
         #exit 1;
     }
 
     $self->set( 'on', $self );
     return $self;
 }
+
 
 # ------------------------------------------------------------------------------
 # Handle device I/O: Read and write messages on the bus
@@ -449,8 +473,13 @@ sub new {
 =cut
 
 my @outqueue = ();    # Queue of messages to be sent
+my $check_for_data_first = 1;
 
 sub check_for_data {
+    if( $check_for_data_first ) {
+	$check_for_data_first = 0;
+	mqtt->log( "now checking for new data" );
+    }
     foreach my $inst ( keys %MQTT_Data ) {
         my $self = $MQTT_Data{$inst}{self};
 
@@ -464,18 +493,12 @@ sub check_for_data {
             ### @FIXME: failed connection
             if ( 'off' ne $self->{state} ) {
 
-                if ( $$self{recon_timer}->inactive ) {
-                    ::print_log("*** mqtt $inst connection failed ($$self{host}/$$self{port}/$$self{topic}), I will try to reconnect in 20 seconds");
-                    $$self{recon_timer}->set( 20, sub { $MQTT_Data{$inst}{self}->mqtt_connect() } );
-                }
+		if ($$self{recon_timer}->inactive) {
+            		$self->log("$inst connection failed ($$self{host}/$$self{port}/$$self{topic}), I will try to reconnect in 20 seconds");
+            		$$self{recon_timer}->set(20, sub { $MQTT_Data{$inst}{self}->mqtt_connect() });
+		}
 
                 # check the state to see if it's off already
-
-=begin comment
-03/29/15 11:17:47 AM *** mqtt mqtt_4 failed (m11.cloudmqtt.com/15050/home/network/#)
-03/29/15 11:17:47 AM *** mqtt mqtt set mqtt_4: [(off), undefined set_by, $mqtt_4]
-03/29/15 11:17:47 AM *** mqtt mqtt set mqtt_4: isa mqtt
-=cut
 
                 $self->set( 'off', $self );
             }
@@ -485,7 +508,7 @@ sub check_for_data {
         }
 
         # This one doesn't block
-        my $msg = read_mqtt_msg( $self, $buf );
+        my $msg = $self->read_mqtt_msg();
 
         ### -[ Input ]----------------------------------------------------------
 
@@ -504,10 +527,8 @@ sub check_for_data {
                 ###
                 ### Someone published something, deal with it
                 ###
-                if ( $main::Debug{mqtt} ) {
-                    &main::print_log( "*** mqtt $inst check_for_data rcv'd: T:" . $msg->topic, ", M:", $msg->message );
-                    &main::print_log( "*** mqtt $inst check_for_data rcv'd: S:" . $msg->string . "," );
-                }
+		$self->debug( 1, "$inst Rcv'd: R:$$msg{retain} T:'$$msg{topic}' M:'$$msg{message}'"  );
+		# $self->debug( 1, "$inst Rcv'd: S:'" . $msg->string . "'", 3 );
 
                 ###
                 ### So we want the topic and the message
@@ -521,14 +542,13 @@ sub check_for_data {
             }
             elsif ( $msg->message_type == MQTT_PINGRESP ) {
                 $$self{got_ping_response} = 1;
-                &main::print_log( "*** mqtt $inst check_for_data Ping rcvd: " . $msg->string )
-                  if ( $main::Debug{mqtt} );
+                $self->debug( 2, "$inst check_for_data Ping rcvd" );
+                $self->debug( 3, "Ping msg: " . Dumper( $msg ) );
             }
             else {
                 # "$msg->string"
                 # Net::MQTT::Message::SubAck=HASH(0x2da94e0)->string
-                &main::print_log( "*** mqtt $inst check_for_data Received: " . $msg->string )
-                  if ( $main::Debug{mqtt} );
+                $self->debug( 1, "$inst check_for_data UNHANDLED MQTT MESSAGE Received: " . Dumper( $msg ) );
             }
         }
 
@@ -545,7 +565,7 @@ sub check_for_data {
 	    ### Okay this is the other hard part
 	    ### 
 	    #send_mqtt_msg($mref));
-	    &main::print_log ("*** mqtt $inst check_for_data send_mqtt_msg $mref ") if ($main::Debug{mqtt});
+	    $self->debug( 1, "$inst check_for_data send_mqtt_msg $mref ");
 	}
 =cut
 
@@ -559,7 +579,7 @@ sub check_for_data {
             ###
             ### We've exceeded the ping time
             ###
-            &main::print_log("*** mqtt $inst read_mqtt_msg Ping Response timeout.")
+            $self->log("$inst read_mqtt_msg Ping Response timeout.")
               unless ( $$self{got_ping_response} );
             ###
             ### This has confused me, I'm not certain if I should put it back in or not
@@ -567,8 +587,7 @@ sub check_for_data {
             ###
             # return unless ($$self{got_ping_response});
 
-            &main::print_log("*** mqtt $inst read_mqtt_msg Ping Request")
-              if ( $main::Debug{mqtt} );
+            $self->debug( 2, "$inst read_mqtt_msg Ping Request" );
             send_mqtt_msg( $self, message_type => MQTT_PINGREQ );
             $$self{got_ping_response} = 0;
         }
@@ -581,11 +600,12 @@ sub check_for_data {
 =cut
 
 sub send_mqtt_msg {
-    my $self = shift;
+    my ( $self, %p_objects ) = @_;
 
-    my $msg = Net::MQTT::Message->new(@_);
+    my $msg = Net::MQTT::Message->new(%p_objects);
     $msg = $msg->bytes;
 
+    # print( "writing to mqtt socket '$msg'\n" );
     # syswrite ?
     syswrite $$self{socket}, $msg, length $msg;
 
@@ -609,11 +629,14 @@ sub read_mqtt_msg {
         ###
         ### I really need to sit down and figure this out
         ###
-        my $mqtt = Net::MQTT::Message->new_from_bytes( $_[0], 1 );
+        my $mqtt = Net::MQTT::Message->new_from_bytes( $self->{buf}, 1 );
         #
         # I am a little confused by this
         #
-        return $mqtt if ( defined $mqtt );
+	if( defined $mqtt ) {
+	    # print( "read_mqtt_msg $self->{instance} returning a message -- remaining buffer '$self->{buf}'\n" );
+	    return $mqtt;
+	}
 
         ### very short wait
         ### Return if there is no data
@@ -623,20 +646,20 @@ sub read_mqtt_msg {
         $timeout = $$self{next_ping} - Time::HiRes::time;
 
         # can return undef (error) or 0 bytes (eof)
-        my $bytes = sysread $$self{socket}, $_[0], 2048, length $_[0];
+        my $bytes = sysread $$self{socket}, $self->{buf}, 2048, length $self->{buf};
 
         # We get no bytes if there is an error or the socket has closed
         unless ($bytes) {
-            my $inst = $$self{instance};
-            if ( $$self{recon_timer}->inactive ) {
-                ::print_log( "*** mqtt $$self{instance}: read_mqtt_msg Socket closed " . ( defined $bytes ? 'gracefully ' : "with error [ $! ]" ) );
-                ::print_log("*** mqtt instance $$self{instance} will try to reconnect in 20 seconds");
-                $$self{recon_timer}->set( 20, sub { $MQTT_Data{$inst}{self}->mqtt_connect() } );
-            }
+	    my $inst = $$self{instance};
+            if ($$self{recon_timer}->inactive) {
+		 $self->log( "$$self{instance}: read_mqtt_msg Socket closed " . ( defined $bytes ? 'gracefully ' : "with error [ $! ]" ) );
+		 $self->log( "This could be caused by sending an ill formed mqtt message, and the broker closed the socket" );
+		 $self->log( "instance $$self{instance} will try to reconnect in 20 seconds");
+		 $$self{recon_timer}->set(20, sub { $MQTT_Data{$inst}{self}->mqtt_connect() });
+	    }
 
             # Not a permanent solution just a way to keep debugging
-            #&main::print_log( "*** mqtt deleting $$self{instance}\n" . Dumper( \$self ) )
-            #  if ( $main::Debug{mqtt} );
+            #$self->debug( "1, deleting $$self{instance}\n" . Dumper( \$self ) );
             #delete( $MQTT_Data{ $$self{instance} } );
 
             return;
@@ -656,7 +679,7 @@ sub read_mqtt_msg_timeout {
     my $timeout = $$self{next_ping} - Time::HiRes::time;
 
     do {
-        my $mqtt = Net::MQTT::Message->new_from_bytes( $_[0], 1 );
+        my $mqtt = Net::MQTT::Message->new_from_bytes( $self->{buf}, 1 );
 
         return $mqtt if ( defined $mqtt );
 
@@ -669,15 +692,14 @@ sub read_mqtt_msg_timeout {
         $timeout = $$self{next_ping} - Time::HiRes::time;
 
         # can return undef (error) or 0 bytes (eof)
-        my $bytes = sysread $$self{socket}, $_[0], 2048, length $_[0];
+        my $bytes = sysread $$self{socket}, $self->{buf}, 2048, length $self->{buf};
 
         # We get no bytes if there is an error or the socket has closed
         unless ($bytes) {
-            &main::print_log( "*** mqtt $$self{instance}: read_mqtt_msg Socket closed " . ( defined $bytes ? 'gracefully ' : "with error [ $! ]" ) );
+            $self->log( "$$self{instance}: read_mqtt_msg Socket closed " . ( defined $bytes ? 'gracefully ' : "with error [ $! ]" ) );
 
             # Not a permanent solution just a way to keep debugging
-            &main::print_log( "*** mqtt deleting $$self{instance}\n" . Dumper( \$self ) )
-              if ( $main::Debug{mqtt} );
+            $self->debug( 1, "deleting $$self{instance}\n" . Dumper( \$self ) );
             delete( $MQTT_Data{ $$self{instance} } );
 
             return;
@@ -698,11 +720,11 @@ sub set {
         $xStr .= defined($set_by) ? ", ($set_by)" : ", undefined set_by, Obj: ";
         $xStr .= defined( $$self{object_name} ) ? ", $$self{object_name}" : ", undefined object_name";    # @FIXME: Use of uninitialized value
 
-        &main::print_log("*** mqtt mqtt set $$self{instance}: [$xStr]");
-        &main::print_log(
+        $self->debug( 1, "mqtt set $$self{instance}: [$xStr]");
+        $self->debug( 1,
             $self->isa('mqtt')
-            ? "*** mqtt mqtt set $$self{instance}: isa mqtt"
-            : "*** mqtt mqtt set $$self{instance}: is nota mqtt"
+            ? "mqtt set $$self{instance}: isa mqtt"
+            : "mqtt set $$self{instance}: is nota mqtt"
         );
     }
 
@@ -742,21 +764,22 @@ sub set {
 ### a write?)
 ###
 sub pub_msg {
-    my $self = shift;
+    my ( $self, %p_objects ) = @_;
 
     # Check for connectivity
     if ( $self->isNotConnected() ) {
 
         # First say something
-        &main::print_log("*** mqtt $$self{instance} failed ($$self{host}/$$self{port}/$$self{topic})");
+        $self->error("$$self{instance} is not connected -- publish failed to $p_objects{topic}");
 
         # Then do something (reconnect)
 
         # Skip if we're not connected
         return;
     }
+    $self->debug( 1, "$$self{instance} Pub: R:$p_objects{retain} T:'$p_objects{topic}' M:'$p_objects{message}'" );
 
-    $self->send_mqtt_msg(@_);
+    $self->send_mqtt_msg(%p_objects);
 }
 
 # ------------------------------------------------------------------------------
@@ -803,7 +826,7 @@ sub add_item {
 sub remove_all_items {
     my ($self) = @_;
 
-    &main::print_log("*** mqtt mqtt remove_all_items()");
+    $self->log("mqtt remove_all_items()");
 
 =begin comment
     if (ref $$self{objects}) {
@@ -878,6 +901,13 @@ sub remove_item {
 sub parse_data_to_obj {
     my ( $self, $msg, $p_setby ) = @_;
 
+    $self->debug( 3, "Msg object: " . Dumper( $msg ) );
+
+    if( !$msg->{message} ) {
+	# cleanup message -- ignore
+	return;
+    }
+
     # 20-12-2020 added support for wildcard mqtt devices e.g. in items.mht
     # MQTT_DEVICE, MQTT_test_wildcard, , mqtt_1, tele/+/LWT
     # or for a multilevel wildcard
@@ -885,45 +915,168 @@ sub parse_data_to_obj {
     # NOTE, use of multi level wildcards can consume a lot of CPU
     # it also exits the loop if it finds a match for speed when there is a large number of mqtt devices
 
-    my ( @split_incoming, @split_device, $counter, $device_topic, $message_topic );
+    my ( @split_incoming, @split_device, $counter, $device_topic, $message_handled );
     #
-    $message_topic = "$$msg{topic}";
+    $message_handled = 0;
     for my $obj ( @{ $$self{objects} } ) {
-        $device_topic = $obj->{topic};
-
-        # check if this mqtt device is a wildcard, and if so replace the wildcard characters
-        # with the incoming message topic pieces
-        if (   index( $device_topic, "\+" ) > 0
-            || index( $device_topic, "\#" ) > 0 )
-        {
-            @split_incoming = split( "/", $$msg{topic} );
-            @split_device   = split( "/", $device_topic );
-            $counter        = 0;
-            foreach (@split_device) {
-                if ( $split_device[$counter] eq "+" ) {
-                    $device_topic =~ s/\+/$split_incoming[$counter]/;
-                }
-                if ( $split_device[$counter] eq "#" ) {
-                    $device_topic = substr( $device_topic, 0, index( $device_topic, "#" ) ) . substr( $$msg{topic}, index( $device_topic, "#" ) );
-                    last;
-                }
-                $counter++;
-            }
-        }
-
-        # the edited device topic is now ready to compare with the incoming message topic
-        if ( $device_topic eq $message_topic ) {
-            $obj->set( $$msg{message}, $self, );
-            $obj->{set_by_topic} = $message_topic;
-
-            # one we have a match, no need to examine any more devices
-            last;
-        }
+	# 2021/2/4 -- added support for a mqtt object to listen for a list of topics
+	my @topiclist;
+	if( ref $obj->{topic} eq 'ARRAY' ) {
+	    @topiclist = @{$obj->{topic}};
+	} else {
+	    @topiclist = ( $obj->{topic} );
+	}
+        for $device_topic (@topiclist) {
+	    # check if this mqtt device is a wildcard, and if so replace the wildcard characters
+	    # with the incoming message topic pieces
+	    if (   index( $device_topic, "\+" ) >= 0
+		|| index( $device_topic, "\#" ) >= 0 )
+	    {
+		@split_incoming = split( "/", $msg->{topic} );
+		@split_device   = split( "/", $device_topic );
+		$counter        = 0;
+		foreach (@split_device) {
+		    if ( $split_device[$counter] eq "+" ) {
+			$device_topic =~ s/\+/$split_incoming[$counter]/;
+		    }
+		    if ( $split_device[$counter] eq "#" ) {
+			$device_topic = substr( $device_topic, 0, index( $device_topic, "#" ) ) . substr( $$msg{topic}, index( $device_topic, "#" ) );
+			last;
+		    }
+		    $counter++;
+		}
+	    }
+    
+	    # the edited device topic is now ready to compare with the incoming message topic
+	    if ( $device_topic eq $msg->{topic} ) {
+		if( $obj->can( 'receive_mqtt_message' ) ) {
+		    $obj->receive_mqtt_message( $msg->{topic}, $msg->{message}, $msg->{retain} );
+		} else {
+		    $obj->{mqtt_retained} = $msg->{retain};
+		    $obj->{set_by_topic} = $msg->{topic};
+		    $obj->set( $msg->{message}, $self );
+		}
+		$message_handled = 1;
+    
+		# Note that multiple objects may listen for same topic and distinguish based on payload - must keep looping
+		# last;
+	    }
+	}
     }
+    if( !$message_handled ) {
+	$self->debug( 2, "UNHANDLED MESSAGE $$msg{topic} -- $$msg{message}" );
+    }
+    if( $msg->{retain} ) {
+	# this is a retained message from the mqtt broker -- record it so if we want to clean up the retained messages in the broker, we can
+	$self->debug( 2, "ADDED RETAINED TOPIC $$msg{topic}" );
+	$self->{retained_topics}->{$$msg{topic}} = $message_handled;
+    }
+}
 
-=begin comment
+# ------------------------------------------------------------------------------
+
+=item C<(get_interface_list())>
 =cut
 
+sub get_interface_list {
+    my @interfaces;
+
+    for my $inst (keys %MQTT_Data) {
+	push @interfaces, $MQTT_Data{$inst}{self};
+    }
+    return ( @interfaces );
+}
+
+# ------------------------------------------------------------------------------
+
+=item C<(cleanup_retained_topics())>
+=cut
+
+sub cleanup_retained_topics {
+    my ($self, @topic_pattern_list) = @_;
+    my $clean_count;
+    my $ignore_count;
+
+    if( scalar(@topic_pattern_list) == 0 ) {
+	mqtt::error( "cleanup_retained_topics -- must specify pattern" );
+	return;
+    }
+    $self->debug( 2, "cleanup topic pattern list: @topic_pattern_list" );
+    $clean_count = 0;
+    $ignore_count = 0;
+    for my $topic ( keys %{$self->{retained_topics}} ) {
+	my $match = 0;
+	for my $topic_pattern (@topic_pattern_list) {
+	    if( $topic_pattern ) {
+		if( $topic =~ m|^${topic_pattern}| ) {
+		    $match = 1;
+		}
+	    }
+	}
+	if( $match ) {
+	    ++$clean_count;
+	    $self->pub_msg( 
+		message_type => MQTT_PUBLISH,
+		retain       => 1,
+		topic        => $topic,
+		message      => ''
+	    );
+	    delete $self->{retained_topics}->{$topic};
+	} else {
+	    ++$ignore_count;
+	    $self->debug( 2, "'$topic' being ignored for cleanup" );
+	}
+    }
+    $self->log( "Cleanup unhandled topics for $self->{instance} complete:  $clean_count cleaned, $ignore_count ignored" );
+}
+
+
+=item C<(list_retained_topics())>
+=cut
+
+sub list_retained_topics {
+    foreach my $interface ( &get_interface_list() ) {
+	for my $topic ( keys %{$interface->{retained_topics}} ) {
+	    my $handled = $interface->{retained_topics}->{$topic};
+	    $interface->log( "$$interface{instance} retained topic: ($handled) $topic" );
+	}
+    }
+}
+
+
+# ------------------------------------------------------------------------------
+
+
+=item C<(publish_mqtt_message())>
+=cut
+
+sub publish_mqtt_message {
+    my ($self, $topic, $msg, $retain ) = @_;
+
+    $retain = 0 if !defined($retain);
+    $self->pub_msg( 
+	message_type => MQTT_PUBLISH,
+	retain       => $retain,
+	topic        => $topic,
+	message      => $msg
+    );
+}
+
+# ------------------------------------------------------------------------------
+
+=item C<(broadcast_mqtt_message())>
+=cut
+
+sub broadcast_mqtt_message {
+    my ($topic, $msg, $retain ) = @_;
+    my @instances;
+
+    $retain = 0 if !defined($retain);
+    (@instances) = (keys %MQTT_Data);
+    foreach my $inst ( @instances ) {
+        my $self = $MQTT_Data{$inst}{self};
+	$self->publish_mqtt_message( $topic, $msg, $retain );
+    }
 }
 
 # -[ Fini - mqtt ]--------------------------------------------------------------
@@ -1021,21 +1174,18 @@ sub set {
         ###
         ### Incoming (MQTT to MH)
         ###
-        &::print_log( "*** mqtt mqtt_Item nom to MQTT to MH " . $self->get_object_name() . "::set($msg, $p_setby)" )
-          if $main::Debug{mqtt};
+        $self->debug( 1, "mqtt_Item nom to MQTT to MH " . $self->get_object_name() . "::set($msg, $p_setby)" );
     }
     else {
         ###
         ### Outgoing (MH to MQTT)
         ###
-        if ( $main::Debug{mqtt} ) {
-            if ( defined( $self->get_object_name() ) ) {
-                &::print_log( "*** mqtt mqtt_Item nom to MH to MQTT (" . $self->get_object_name() . ') no p_setby ::set($msg, $p_setby)' );
-            }
-            else {
-                &::print_log('*** mqtt mqtt_Item nom to MH to MQTT () no p_setby ::set($msg, $p_setby)');
-            }
-        }
+	if ( defined( $self->get_object_name() ) ) {
+	    $self->debug( 1, "mqtt_Item nom to MH to MQTT (" . $self->get_object_name() . ") no p_setby ::set($msg, $p_setby)" );
+	}
+	else {
+	    $self->debug( 1, "mqtt_Item nom to MH to MQTT () no p_setby ::set($msg, $p_setby)" );
+	}
         ###
         ### I need the instance socket, the obj's topic and message
         ### in order to send the message

--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -936,7 +936,7 @@ sub parse_data_to_obj {
 		@split_device   = split( "/", $device_topic );
 		$counter        = 0;
 		foreach (@split_device) {
-		    if ( $split_device[$counter] eq "+" ) {
+		    if ( $split_device[$counter] eq "+"  &&  defined $split_incoming[$counter] ) {
 			$device_topic =~ s/\+/$split_incoming[$counter]/;
 		    }
 		    if ( $split_device[$counter] eq "#" ) {

--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -989,7 +989,15 @@ sub get_interface_list {
 
 # ------------------------------------------------------------------------------
 
-=item C<(cleanup_retained_topics())>
+=item C<(cleanup_retained_topics( @pattern_list ))>
+
+Over time, retained messages accumulate in the broker.  When objects change names
+or are removed from your setup, the retained messages remain.
+
+This function is used to delete retained topics from the broker.  It will
+publish an empty message to all retained topics matching a pattern in the
+pattern list that misterhouse has received from this broker.
+
 =cut
 
 sub cleanup_retained_topics {
@@ -1032,6 +1040,10 @@ sub cleanup_retained_topics {
 
 
 =item C<(list_retained_topics())>
+
+This function will list all retained topics received by misterhouse, and some
+indication as to whether the topic was handled by some defined object.
+
 =cut
 
 sub list_retained_topics {
@@ -1047,7 +1059,10 @@ sub list_retained_topics {
 # ------------------------------------------------------------------------------
 
 
-=item C<(publish_mqtt_message())>
+=item C<(publish_mqtt_message( topic, message, retain ))>
+
+Publish an mqtt message.
+
 =cut
 
 sub publish_mqtt_message {
@@ -1064,7 +1079,10 @@ sub publish_mqtt_message {
 
 # ------------------------------------------------------------------------------
 
-=item C<(broadcast_mqtt_message())>
+=item C<(broadcast_mqtt_message( topic, message, retain ))>
+
+Broadcast an mqtt message to all defined brokers.
+
 =cut
 
 sub broadcast_mqtt_message {

--- a/lib/mqtt_discovery.pm
+++ b/lib/mqtt_discovery.pm
@@ -243,22 +243,30 @@ sub get_object_name {
     return $self->{object_name};
 }
 
-sub debug {
-    my( $self, $level, $msg ) = @_;
-    if( $self->{debug} >= $level ) {
-	$level = 0;
-    }
-    &mqtt::debug( $self->{interface}, $level, $msg );
+sub log {
+    my( $self, $str ) = @_;
+    &main::print_log( 'MQTTDisc: '. $str );
 }
 
 sub error {
-    my( $self, $msg ) = @_;
-    &mqtt::error( $self->{interface}, $msg );
+    my( $self, $str ) = @_;
+    &main::print_log( "MQTTDisc ERROR: $str" );
 }
 
-sub log {
-    my( $self, $msg ) = @_;
-    &mqtt::log( $self->{interface}, $msg );
+sub debug {
+    my( $self, $level, $str ) = @_;
+    my $objname;
+    $objname = lc $self->get_object_name() if $self;
+    if( $main::Debug{'mqtt'} >= $level  ||  ($objname && $main::Debug{$objname} >= $level) ) {
+	&main::print_log( "MQTTDisc D$level: $str" );
+    }
+}
+
+sub set_object_debug {
+    my( $self, $level ) = @_;
+    my $objname = lc $self->get_object_name();
+    $level = 1 if !defined $level;
+    $main::Debug{$objname} = $level;
 }
 
 =item C<receive_mqtt_message( mqtt_topic, mqtt_message, mqtt_retained)>

--- a/lib/mqtt_discovery.pm
+++ b/lib/mqtt_discovery.pm
@@ -1,0 +1,380 @@
+# ------------------------------------------------------------------------------
+
+=begin comment
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+    =head1 B<mqtt_Discovery> B<mqtt_DiscoveredItem>
+
+    Dave Neudoerffer <dave@neudoerffer.com>
+
+    =head2 SYNOPSIS
+
+    An MQTT discover module for Misterhouse.
+    Full documentation in mqtt_items.pm.
+
+    Uses existing interface class in mqtt.pm.
+    Uses mqtt_BaseRemoteItem from mqtt_items.pm.
+    It does not use the mqtt_Item class in mqtt.pm.
+
+    =head2 DESCRIPTION
+
+    Misterhouse MQTT discovery for use with many MQTT services.
+
+    MQTT website: http://mqtt.org/
+    MQTT Test service: http//test.mosquitto.org/ (test.mosquitto.org port 1883)
+
+File:
+    mqtt_Discovery.pm
+
+Description:
+    Author(s):
+    Dave Neudoerffer <dave@neudoerffer.com>
+
+    See mqtt_items.pm for full documentation.
+
+License:
+    This free software is licensed under the terms of the GNU public license.
+
+Usage:
+
+Notes:
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+=cut
+
+# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+
+package mqtt_DiscoveredItem;
+
+use strict;
+
+use JSON qw( decode_json encode_json );   
+use Data::Dumper;
+use mqtt_items;
+
+@mqtt_DiscoveredItem::ISA = ( 'mqtt_BaseRemoteItem' );
+
+
+=item C<new(mqtt_discovery_object, name, discovery_topic, discovery_msg)>
+
+    Crease a mqtt_BaseRemoteItem based on the discovery_topic and discovery_msg
+
+=cut
+
+sub new {   #### mqtt_DiscoveredItem
+    my ( $class, $disc_obj, $name, $disc_topic, $disc_msg ) = @_;
+    my $obj;
+    my $obj_name;
+    my $interface = $disc_obj->{interface};
+    my $device_name;
+    my $self;
+    my $short_disc_topic;
+
+
+    my ($disc_prefix, $disc_type, $realm, $device_id) = $disc_topic =~ m|^(.*)/([^/]*)/([^/]+)/([^/]+)/config$|;
+    if( $disc_prefix ) {
+	$short_disc_topic = "$disc_type/$realm/$device_id/config";
+    } else {
+	($disc_prefix, $disc_type, $device_id) = $disc_topic =~ m|^(.*)/([^/]+)/([^/]+)/config$|;
+	if( !$disc_prefix ) {
+	    $disc_obj->error( "UNRECOGNIZED DISCOVERY MESSAGE -- can't parse: $disc_topic" );
+	    return;
+	}
+	$short_disc_topic = "$disc_type/$device_id/config";
+    }
+
+    my $disc_info;
+    eval{ $disc_info = decode_json( $disc_msg ) };
+    if( !$disc_info ) {
+	$disc_obj->error( "UNRECOGNIZED DISCOVERY MESSAGE -- payload not json: $disc_topic -- M:'$disc_msg'" );
+	return;
+    }
+
+    &mqtt_BaseItem::normalize_discovery_info( $disc_info );
+
+    $disc_obj->debug( 3, "processing discovery message payload:\n" . Dumper($disc_info) );
+
+    # map discovery type to mqtt object type
+    if( $disc_type eq 'light' ) {
+	if( $disc_info->{schema} eq 'template' ) {
+	    $disc_obj->log( "Discovery schema 'template' not supported" );
+	    return;
+	}
+    } elsif( $disc_type eq 'binary_sensor' ) {
+    } elsif( $disc_type eq 'sensor' ) {
+    } elsif( $disc_type eq 'switch' ) {
+    } else {
+	$disc_obj->log( "UNRECOGNIZED DISCOVERY TYPE: $disc_type" );
+	return;
+    }
+
+    # Set the listentopics list to all discovery parms that end with _topic
+    #
+    my @listentopics = ();
+    foreach my $disc_parm ( keys %{$disc_info} ) {
+	if( $disc_parm =~ /^.*_topic$/ ) {
+	    push @listentopics, $disc_info->{$disc_parm};
+	}
+    }
+    if( $#listentopics < 0 ) {
+	$disc_obj->error( "UNRECOGNIZED DISCOVERY MESSAGE -- no topic: $disc_topic -- M:'$disc_msg" );
+	return;
+    } 
+
+    # Check for objects that already exist -- for example, if they were persisted in a .mht file
+    my $found = 0;
+    for $obj ( @{ $interface->{objects} } ) {
+	if( $obj->{disc_info}->{unique_id} eq $device_id ) {
+	    if( $obj->{local_item} ) {
+		$disc_obj->debug( 1, "Ignoring discovery message received for local object: " . $obj->{local_item}->get_object_name );
+	    } else {
+		if( $short_disc_topic eq $obj->{disc_topic} ) {
+		    $disc_obj->debug( 1, "Discovery message received for device_id ($device_id) for object that already exists: " . $obj->get_object_name );
+		    # Update the discover message so that if discovered items are written out, they get the new ones
+		    $obj->{disc_msg} = $disc_msg;
+		} else {
+		    $disc_obj->error( "Discovery message received for device_id $device_id, but topics don't match" );
+		}
+	    }
+	    $found = 1;
+	} elsif( $obj->{disc_info}->{name} eq $disc_info->{name} ) {
+	    # Note that Home Assistant matches discovery objects up based on friendly name -- report error on duplicate friendly names
+	    $disc_obj->error( "Discovery message received for friendly_name ($disc_info->{name}) that already exists" );
+	    $found = 1;
+	}
+    }
+    if( $found ) {
+	return;
+    }
+
+    # create local MH object
+    $obj_name = 'mqtt_';
+    if( $realm ) {
+	#  $realm helps to identify the device
+	$obj_name .= "${realm}_";
+    }
+    if( $disc_info->{name} ) {
+	$obj_name .= $disc_info->{name};
+    } else {
+	$obj_name .= $device_id;
+    }
+    $obj_name =~ s/ /_/g;
+    $obj = ::get_object_by_name( $obj_name );
+    if( $obj ) {
+	$disc_obj->error( "Trying to create object that already exists: $obj_name" );
+	return;
+    } 
+
+    $self = new mqtt_BaseRemoteItem( $interface, $obj_name, $disc_type, \@listentopics, 0 );
+
+    bless $self, $class;
+
+    $self->{disc_info}	= $disc_info;
+    $self->{disc_topic} = $short_disc_topic;
+    $self->{disc_prefix} = $disc_prefix;
+    $self->{disc_msg}	= $disc_msg;
+    $self->{disc_obj}	= $disc_obj;
+    $self->{discovered} = 1;
+
+    $obj_name = $disc_obj->get_object_name;
+    $self->debug( 1, "New mqtt_DiscoveredItem( $obj_name, '$name', '$disc_topic', '$disc_msg' )" );
+
+    $Data::Dumper::Maxdepth = 3;
+    $self->debug( 3, "DiscoveryItem created: \n" . Dumper( $self ) );
+
+    # We may need flags to deal with XML, JSON or Text
+    return $self;
+}
+
+
+# -[ Fini - mqtt_DiscoveredItem ]---------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+
+package mqtt_Discovery;
+
+use strict;
+
+use JSON qw( decode_json encode_json );   
+use Data::Dumper;
+
+my $discovered_items_filename;
+
+=item C<new(name, mqtt_interface, topic, retain, qos)>
+
+    Creates a MQTT Discovery object that will handle mqtt discovery messages and create local objects.
+    Then use class function write_discovered_items to write them out to a .mht file.
+    Use publish_discovery_data to publish MQTT discovery messages for all discoverable items.
+
+=cut
+
+sub new {  ### mqtt_Discovery
+    my ( $class, $interface, $name, $discovery_topic ) = @_;
+
+    my $self = {};
+
+    bless $self, $class;
+
+    # $self->{debug} = 3;
+
+    $self->{interface}	    = $interface;
+    $self->{object_name}    = $name;
+    $self->{mqtt_type}	    = 'discovery';
+    $self->{discoverable}   = 0;
+    $self->{discovery_topic} = $discovery_topic;
+    $self->{topic}	    = "${discovery_topic}/#";
+
+    if( $self->{interface} ) {
+	$self->{interface}->add( $self );
+    } else {
+	foreach $interface ( &mqtt::get_interface_list() ) {
+	    $interface->add( $self );
+	}
+    }
+
+    $self->debug( 1, "New mqtt_Discovery( $interface->{instance}, '$name', '$discovery_topic' )" );
+
+    return $self;
+}
+
+sub get_object_name {
+    my( $self ) = @_;
+    return $self->{object_name};
+}
+
+sub debug {
+    my( $self, $level, $msg ) = @_;
+    if( $self->{debug} >= $level ) {
+	$level = 0;
+    }
+    &mqtt::debug( $self->{interface}, $level, $msg );
+}
+
+sub error {
+    my( $self, $msg ) = @_;
+    &mqtt::error( $self->{interface}, $msg );
+}
+
+sub log {
+    my( $self, $msg ) = @_;
+    &mqtt::log( $self->{interface}, $msg );
+}
+
+=item C<receive_mqtt_message( mqtt_topic, mqtt_message, mqtt_retained)>
+=cut
+
+sub receive_mqtt_message {
+    my ( $self, $mqtt_topic, $mqtt_msg, $mqtt_retained ) = @_;
+    my $obj_name;
+    my $obj;
+    my $interface = $self->{interface};
+
+    if( !$mqtt_msg ) {
+	$self->debug( 2, "INGNORING DISCOVERY CLEAN MESSAGE: $mqtt_topic -- M:'$mqtt_msg'" );
+	return;
+    }
+
+    $obj = new mqtt_DiscoveredItem( $self, undef, $mqtt_topic, $mqtt_msg );
+
+    if( $obj ) {
+	my $obj_name = $obj->{mqtt_name};
+	$obj->{category} = "MQTT Discovered Items";
+	$obj->{filename} = "mqtt_discovery";
+	$obj->{object_name} = "\$$obj_name";
+	&main::register_object_by_name("\$$obj_name",$obj);
+    }
+
+    if( $discovered_items_filename ) {
+	&write_discovered_items( $discovered_items_filename );
+    }
+
+}
+
+
+######
+# These next subs could be in the mqtt class... but I wanted to keep the discovery functions together
+######
+
+
+=item C<write_discovered_items(filename, autoupdate)>
+
+    Writes out all mqtt items that have been discovered to a .mqt file.
+    Note that this includes items that were created locally as discovered
+    items in a .mht file as well as newly discovered items.
+    If autoupdate is true, the file will be updated with each new discovery message.
+
+=cut
+
+sub write_discovered_items {
+    my ($outfilename, $autoupdate) = @_;
+    my $interface;
+    my $f;
+    my @sorted_list;
+    
+    &debug( undef, 1, "Writing discovered items to '$outfilename'" );
+    if( defined $autoupdate ) {
+	if( $autoupdate ) {
+	    $discovered_items_filename = $outfilename;
+	} else {
+	    $discovered_items_filename = undef;
+	}
+    }
+    if( !open( $f, "> ${outfilename}" ) ) {
+	&mqtt->error( "Unable to open discovery target file '${outfilename}" );
+	return;
+    }
+    print {$f} "Format = A\n\n";
+    foreach my $interface ( &mqtt::get_interface_list() ) {
+	@sorted_list = sort { $a->get_object_name() cmp $b->get_object_name() } @{$interface->{objects}};
+	for my $obj ( @sorted_list ) {
+	    if( $obj->{discovered} ) {
+		my $obj_name = $obj->get_object_name;
+		my $disc_obj_name = $obj->{disc_obj}->get_object_name;
+		my $disc_topic = "$obj->{disc_prefix}/$obj->{disc_topic}";
+		$obj_name =~ s/^\$//;
+		$disc_obj_name =~ s/^\$//;
+		print {$f} "MQTT_DISCOVEREDITEM, $obj_name, $disc_obj_name, $disc_topic, $obj->{disc_msg}\n";
+	    }
+	}
+    }
+    close( $f );
+}
+
+=item C<(publish_discovery_data())>
+=cut
+
+sub publish_discovery_data {
+    my ($self) = @_;
+    my $obj;
+    my $interface;
+    my $topic;
+    my $msg;
+
+    $interface = $self->{interface};
+    if( !$interface->isConnected ) {
+	$self->error( "Unable to publish discovery data -- $interface->{instance} not connected" );
+	return 0;
+    }
+    $self->log( "Publishing discovery data" );
+    for my $obj ( @{ $$interface{objects} } ) {
+	if( !$obj->{discoverable} ) {
+	    $self->debug( 1, "Non-discoverable object skipped: ".  $obj->get_object_name );
+	} else {
+	    my ($topic, $msg) = ($obj->{disc_topic}, $obj->{disc_msg});
+            if( $topic ) {
+		$topic = "$self->{discovery_topic}/$topic";
+		$self->debug( 1, "Publishing discovery message T:'$topic'   M:'$msg'" );
+		$obj->transmit_mqtt_message( $topic, $msg, 1 );
+	    }
+	}
+    }
+    return 1;
+}
+
+
+# -[ Fini - mqtt_Discovery ]---------------------------------------------------------
+
+# -[ Fini ]---------------------------------------------------------------------
+1;
+

--- a/lib/mqtt_discovery.pm
+++ b/lib/mqtt_discovery.pm
@@ -124,17 +124,18 @@ sub new {   #### mqtt_DiscoveredItem
 
     # Check for objects that already exist -- for example, if they were persisted in a .mht file
     my $found = 0;
+    my $unique_id = $disc_info->{unique_id}  ||  $device_id;
     for $obj ( @{ $interface->{objects} } ) {
-	if( $obj->{disc_info}->{unique_id} eq $device_id ) {
+	if( $obj->{disc_info}->{unique_id} eq $unique_id ) {
 	    if( $obj->{local_item} ) {
 		$disc_obj->debug( 1, "Ignoring discovery message received for local object: " . $obj->{local_item}->get_object_name );
 	    } else {
 		if( $short_disc_topic eq $obj->{disc_topic} ) {
-		    $disc_obj->debug( 1, "Discovery message received for device_id ($device_id) for object that already exists: " . $obj->get_object_name );
+		    $disc_obj->debug( 1, "Discovery message received for unique_id:($unique_id) for object that already exists: " . $obj->get_object_name );
 		    # Update the discover message so that if discovered items are written out, they get the new ones
 		    $obj->{disc_msg} = $disc_msg;
 		} else {
-		    $disc_obj->error( "Discovery message received for device_id $device_id, but topics don't match" );
+		    $disc_obj->error( "Discovery message received for unique_id:$unique_id, but topics don't match" );
 		}
 	    }
 	    $found = 1;

--- a/lib/mqtt_items.pm
+++ b/lib/mqtt_items.pm
@@ -288,10 +288,12 @@ use Data::Dumper;
 @mqtt_BaseItem::ISA = ( 'Generic_Item' );
 
 
+
 =item C<new(mqtt_interface, name, type, state_topic, command_topic, listen_topic, discoverable, friendly_name )>
 
-    Creates a MQTT Base Item.
-    This function does not setup the {disc_info} structure.  That is left up to the child classes.
+    Creates an MQTT Base Item.
+
+    Note: This function does not setup the {disc_info} structure.  That is left up to the child classes.
 
 =cut
 
@@ -332,6 +334,30 @@ sub new {   ### mqtt_BaseItem
     }
 
     return $self;
+}
+
+sub log {
+    my( $self, $str ) = @_;
+    &main::print_log( 'MQTT: '. $str );
+}
+
+sub error {
+    my( $self, $str ) = @_;
+    &main::print_log( "MQTT ERROR: $str" );
+}
+
+sub debug {
+    my( $self, $level, $str ) = @_;
+    if( $self->debuglevel( $level, 'mqtt' ) ) {
+	&main::print_log( "MQTT D$level: $str" );
+    }
+}
+
+sub set_object_debug {
+    my( $self, $level ) = @_;
+    my $objname = lc $self->get_object_name();
+    $level = 1 if !defined $level;
+    $main::Debug{$objname} = $level;
 }
 
 =item C<is_dimmable()>
@@ -390,30 +416,6 @@ sub level {
 
 }
 
-
-sub set_object_debug {
-    my( $self, $level ) = @_;
-    $level = 1 if !defined $level;
-    $self->{debug_level} = $level;
-}
-
-sub debug {
-    my( $self, $level, $msg ) = @_;
-    if( $self->{debug_level} >= $level ) {
-	$level = 0;
-    }
-    &mqtt::debug( $self->{interface}, $level, $msg );
-}
-
-sub error {
-    my( $self, $msg ) = @_;
-    &mqtt::error( $self->{interface}, $msg );
-}
-
-sub log {
-    my( $self, $msg ) = @_;
-    &mqtt::log( $self->{interface}, $msg );
-}
 
 sub transmit_mqtt_message {
     my( $self, $topic, $msg, $retain ) = @_;

--- a/lib/mqtt_items.pm
+++ b/lib/mqtt_items.pm
@@ -310,19 +310,14 @@ sub new {   ### mqtt_BaseItem
     $self->{discoverable}	    = $discoverable;
     $self->{topic}		    = $listentopics;
     $self->{disc_type}		    = $type;
-    if( $self->{mqtt_type} eq 'light' ) {
-	$self->set_states( "off", "20%", "40%", "50%", "60%", "80%", "on", "offline" );
-    } elsif( $self->{mqtt_type} eq 'binary_sensor' ) {
-	$self->set_states( "off", "on", "offline" );
-    } elsif( $self->{mqtt_type} eq 'sensor' ) {
-    } elsif( $self->{mqtt_type} eq 'switch' ) {
-	$self->set_states( "off", "on", "offline" );
-    } elsif( $self->{mqtt_type} eq 'scene' ) {
-	$self->{disc_type} = 'switch';
-	$self->set_states( "off", "on", "offline" );
-    } else {
+
+    if( !grep( /^$type$/, ('light', 'switch', 'binary_sensor', 'sensor', 'scene') ) ) {
 	$self->error( "UNKNOWN DEVICE TYPE: '$self->{mqtt_name}':$self->{mqtt_type}" );
 	return;
+    }
+
+    if( $self->{mqtt_type} eq 'scene' ) {
+	$self->{disc_type} = 'switch';
     }
 
     if( $self->{interface} ) {
@@ -1110,6 +1105,17 @@ sub new {   ### mqtt_BaseRemoteItem
     my ( $class, $interface, $mqtt_name, $type, $listentopics, $discoverable ) = @_;
 
     my $self = new mqtt_BaseItem( $interface, $mqtt_name, $type, $listentopics, $discoverable );
+
+    if( $self->{mqtt_type} eq 'light' ) {
+	$self->set_states( "off", "20%", "40%", "50%", "60%", "80%", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'binary_sensor' ) {
+	$self->set_states( "off", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'sensor' ) {
+    } elsif( $self->{mqtt_type} eq 'switch' ) {
+	$self->set_states( "off", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'scene' ) {
+	$self->set_states( "off", "on", "offline" );
+    }
 
     bless $self, $class;
 

--- a/lib/mqtt_items.pm
+++ b/lib/mqtt_items.pm
@@ -1,0 +1,1466 @@
+# ------------------------------------------------------------------------------
+
+
+=begin comment
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+    =head1 B<mqtt_BaseItem>
+    =head1     B<mqtt_LocalItem>
+    =head1     B<mqtt_BaseRemoteItem>
+    =head1         B<mqtt_RemoteItem> B<mqtt_InstMqttItem> B<mqtt_DiscoveredItem>
+    =head1 B<mqtt_Discovery>
+
+    Dave Neudoerffer <dave@neudoerffer.com>
+
+    =head2 SYNOPSIS
+
+    An MQTT Items module for Misterhouse.
+    Uses existing interface class in mqtt.pm.
+    It does not use the mqtt_Item class in mqtt.pm.
+
+    Can be used together with mqtt_discovery.pm to publish and process
+    Home Assistant format discovery messages.
+
+    =head2 DESCRIPTION
+
+    Misterhouse MQTT items for use with many MQTT services.
+
+    Home Assistant format discovery message processing.
+
+    MQTT website: http://mqtt.org/
+    MQTT Test service: http//test.mosquitto.org/ (test.mosquitto.org port 1883)
+
+File:
+    mqtt_items.pm
+    mqtt_discovery.pm
+
+Description:
+    This is a misterhouse style items interface for MQTT devices
+
+    For more information about the MQTT protocol:
+        http://mqtt.org
+
+    Author(s):
+    Dave Neudoerffer <dave@neudoerffer.com>
+
+    MQTT Items (mqtt_items.pm)
+    --------------------------
+
+    There are several MQTT item types implemented in this module (see below).
+
+    Each item can handle both commands and state messages to/from MQTT devices.
+    LWT messages can also be handled for remote items.
+
+    There are several classes implemented in mqtt_items.pm:
+
+    mqtt_BaseItem:
+         - is the base class.
+
+	mqtt_LocalItem:
+	    - implements an mqtt mh item that is tied to a local item
+	    - when the local item changes state, this mqtt item will send mqtt state_topic messages
+	    - it will also listen for mqtt command_topic messages and set the state of the local item,
+	      if the set of the local item is successful, the mqtt item will send out the state_topic message
+	    - a LocalItem can be associated with a specific broker, in which case it will
+	      listen only to that broker for commands and will send state messages only to
+	      that broker
+	    - if there is no broker specified, then the LocalItem will listen to all brokers
+	      for command messages, and broadcast state messages to all brokers
+	    - can publish HA discovery info -- a fairly simple discovery language is
+	      used that is based on the insteon-mqtt project
+
+	mqtt_BaseRemoteItem:
+	    - implements a base class mh item that both sends commands to and
+	      receives state messages from a remote device that directly sends mqtt messages
+	    - a BaseRemoteItem is always associated with a specific mqtt broker
+	    - when set is called, will send command_topic messages to change the state of a device
+	        - local state will not change until state_topic message is received unless
+		  the item is marked as optimistic or does not have a state_topic
+	    - will listen for state_topic messages with stata changes
+	    - will also listen for last will and testiment (LWT) messages reporting
+	      when a device goes offline
+
+	    mqtt_RemoteItem
+	        - implements a statically defined mh item for mqtt devices
+		- it is intended to work with Tasmota, IOT4 and ESPurna devices,
+		  BUT, I have a very limited set of devices to test with
+		    - currently implements switch, light, sensor, binary-sensor
+		    - I only have Tasmota switches, and with tuya convert broken,
+		      I am not able to setup other Tasmota devices
+		      (not into soldering at this point)
+		- Remote devices can also be discovered using the gear in mqtt_discovery.pm
+		  eliminating the need to statically define them, but you need to
+		  turn discovery on on your device (eg. Tasmota: SetOption19 1)
+		  -- note that the Tasmota discovery gear is not being developed anymore...
+		- can publish HA discovery info -- a simpler discovery message
+		  than the discontinued Tasmota discovery mentioned above
+
+	    mqtt_InstMqttItem
+	        - implements a statically defined mh item for Insteon devices managed
+		  by insteon-mqtt
+		- see https://github.com/TD22057/insteon-mqtt
+		- can pulish HA discovery info, as insteon-mqtt does not implement discovery yet
+    
+
+    Discovery (mqtt_discovery.pm):
+    -----------------------------
+
+    This module implements MQTT discovery.  Both publishing discovery information for locally
+    defined devices, as well as receiving discovery information from mqtt devices.
+    The discovery definitions are based on the Home Assistant Discovery info:
+        https://www.home-assistant.io/docs/mqtt/discovery
+
+    There are several uses for mqtt discovery in MH:
+        - discover mqtt devices without having to statically define them in .mht files
+	- publish discovery information for locally defined devices.  This has multiple
+	  uses as well:
+	    - share device information with another MH instance
+	    - publish device information to Home Assistant.  This could be
+	      for environments where both are running, or used when
+	      transitioning one way or the other.
+
+
+    There are 2 classes implemented in mqtt_discovery.pm:
+
+	    mqtt_DiscoveredItem:
+		- implements an mh item from a mqtt discovery message
+		- this class extends the mqtt_BaseRemoteItem class
+		- it has been built to handle 2 types of discovery messages:
+		    1. discovery messages as published by the below discovery
+		       class primarily for mqtt_LocalItems, but discovery info
+		       for RemoteItems and InstMqttItems can also be published.
+		       This allows easy sharing of device definitions between MH instances,
+		       and also allows Home Assistant to know about MH items.
+		    2. discovery messages published by remote devices.
+		       It handles some Tasmota, IOT4 discovery messages published
+		       when Tasmota SetOption19 is set to 1, or HASS discovery turned on
+		       on the IOT4 device.  I don't have any ESPurna devices so I don't
+		       know about discovery for those devices.
+		       - it handles switch, light, sensor and binary-sensor
+		       - so far the handling of discovery messages is somewhat limited due
+			 to my very limited set of these devices
+		       - I have implemented these devices based on HomeAssistant documentation
+		         for discovery and information on blakaddr.com
+		       - In order to implement this properly, we would need a templating engine in perl
+	
+    mqtt_Discovery:
+         - is a class that listens for mqtt discovery messages
+           based on an mqtt wildcard
+	 - creates mqtt_DiscoveredItems based on the published discovery information
+	 - you can then write out these items to a .mht file using the write_discovered_items method
+	     - note that the discovered items will not appear as fully referencable MH items
+	       until you restart MH once.
+         - this class will also publish discovery information for mqtt_LocalItems and
+           even for any of the mqtt_BaseRemoteItems if they are created with the discovery flag set
+
+
+
+License:
+    This free software is licensed under the terms of the GNU public license.
+
+Usage:
+
+    .mht file:
+
+	# MQTT_BROKER,	name,	   subscribe topic,	host/ip,	port,	user,	    pwd,	keepalive
+	MQTT_BROKER,	mqtt_1,	   ,			localhost,	1883,	,	    ,		121
+
+	# MQTT_INSTMQTT,    name,		groups,		broker, type,		topicprefix,				    discoverable    Friendly Name
+	MQTT_INSTMQTT,      bootroom_switch,	Lights,		mqtt_1, switch,		insteoncottage/bootroom,		    1,		    Bootroom Light
+
+	# Define a Tasmota item.  Note that the topicprefix must be in the order that the device will
+	# send.  This is configured in the Tasmota MQTT configuration.  The prefix listed can
+	# be any of stat/tele/cmnd.
+	# MQTT_REMOTEITEM,  name,		groups,		broker, type,		topicprefix,				    discoverable    Friendly Name
+	MQTT_REMOTEITEM,    tas_outdoor_plug,	,		mqtt_1, switch,		tasmota_outdoor_plug/stat,		    0,		    Tasmota Outdoor Plug
+
+
+        # Say you have a local INSTEON item  (could be any kind of misterhouse item)
+	INSTEON_SWITCHLINC, 52.9E.DD,		shed_light,	Lights|Outside
+	#
+        # then you can create an mqtt item to publish its state and receive mqtt commands
+	# MQTT_LOCALITEM,   name,		local item,	broker, type,		topicprefix,				    discoverable    Friendly Name
+	MQTT_LOCALITEM,	    bootroom_switch,	shed_light,	mqtt_1, switch,		insteoncottage/bootroom,		    1,		    Bootroom Light
+	#
+
+
+	###################################################
+	# Use of Discovery functionality is optional
+	###################################################
+
+	# MQTT_DISCOVERY,   obj name,		discovery topic prefix, broker
+	MQTT_DISCOVERY,	    mqtt_discovery1,	homeassistant,		mqtt_1
+	
+    .mht generated file:
+
+	# Discovery items are generated by the write_discovered_items function
+	# You would not normally code these by hand
+	# MQTT_DISCOVEREDITEM,	name,			    discovery_obj,	discovery_topic,			    discovery_message
+	MQTT_DISCOVEREDITEM,	mqtt_tasmota_outdoor_plug,  mqtt_discovery,	 homeassistant/switch/877407_RL_1/config,   {"name":"Tasmota Outside Plug","cmd_t":"~cmnd/POWER","stat_t":"~tele/STATE","val_tpl":"{{value_json.POWER}}","pl_off":"OFF","pl_on":"ON","avty_t":"~tele/LWT","pl_avail":"Online","pl_not_avail":"Offline","uniq_id":"877407_RL_1","device":{"identifiers":["877407"],"connections":[["mac","D8:F1:5B:87:74:07"]]},"~":"tasmota_outdoor_plug/"}
+
+
+    and misterhouse user code:
+
+        #
+	if( $bootroom_switch->{state_now} ) {
+	    &print_log( "Bootroom light set " . $bootroom_switch->state );
+	}
+
+	#
+	if( new_minute(10) ) {
+	    # this will turn on the light by sending an mqtt command
+	    $bootroom_switch->set( 'toggle' );
+
+	    # as the insteon light is toggled with this command, an mqtt state message will be published
+	    $shed_light->set( 'toggle' );
+
+	}
+
+	# this will publish mqtt discovery messages for all discoverable items
+	$mqtt_discovery1->publish_discovery_data();
+
+	# this will write a .mht file with data for all discovered items
+	&mqtt_Discovery::write_discovered_items( "mqtt_discovered_items.mht" );
+
+    CLI generation of a command to the CR_Temp
+
+	TODO:  find a command that works to turn on the $shed_light
+        mosquitto_pub -d -h test.mosquitto.org -q 0 -t test.mosquitto.org/test/x10/1 -m "Off"
+
+Notes:
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+    Special Thanks to:
+    Neil Cherry -- original implementer of misterhouse MQTT support
+    Giles Godard-Brown -- MQTT and Tasmota support
+
+    This code has been developed using the insteon-mqtt public project and
+    using HomeAssistant and using Tasmota devices.
+
+    @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+    =head2 B<Notes:>
+
+    I believe most people using MQTT are running their own mqtt
+    server.  Typically mosquitto.
+
+    If you are using a higher traffic mosquitto server, then you
+    will want to qualify topics more.  That would require configuring
+    your Tasmota devices to have a qualified prefix.
+
+    Discovery:
+    For discovery, there are a lot of devices types out there and a lot of different
+    discovery message formats.  I have handled common device types in this code,
+    but it can be extended to handle many more. I have only been able to implement
+    Tasmota switches and a rough implementation of Tasmota Dimmers based on zapping
+    a device I have to think that it is a dimmer.
+
+    =head2 INHERITS
+
+    B<NONE>
+
+    =head2 METHODS
+
+    =over
+
+    =item B<UnDoc>
+
+    =item B<ToDo>
+
+    There are a number of things that need to be done. There is a lack of error
+    checking and connectivity checks and restoration. I'm sure there are a huge
+    number of features that need to be added.
+
+    @TODO:
+        1. Add more Tasmota types
+
+=cut
+
+# ------------------------------------------------------------------------------
+
+package mqtt_BaseItem;
+
+use strict;
+
+use JSON qw( decode_json encode_json );     #
+use Data::Dumper;
+
+@mqtt_BaseItem::ISA = ( 'Generic_Item' );
+
+
+=item C<new(mqtt_interface, name, type, state_topic, command_topic, listen_topic, discoverable, friendly_name )>
+
+    Creates a MQTT Base Item.
+    This function does not setup the {disc_info} structure.  That is left up to the child classes.
+
+=cut
+
+sub new {   ### mqtt_BaseItem
+    my ( $class, $interface, $mqtt_name, $type, $listentopics, $discoverable ) = @_;
+
+    my $self = new Generic_Item();
+
+    bless $self, $class;
+
+    $self->{interface}		    = $interface;
+    $self->{mqtt_name}		    = $mqtt_name;
+    $self->{mqtt_type}		    = $type;
+    $self->{discoverable}	    = $discoverable;
+    $self->{topic}		    = $listentopics;
+    $self->{disc_type}		    = $type;
+    if( $self->{mqtt_type} eq 'light' ) {
+	$self->set_states( "off", "20%", "40%", "50%", "60%", "80%", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'binary_sensor' ) {
+	$self->set_states( "off", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'sensor' ) {
+    } elsif( $self->{mqtt_type} eq 'switch' ) {
+	$self->set_states( "off", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'scene' ) {
+	$self->{disc_type} = 'switch';
+	$self->set_states( "off", "on", "offline" );
+    } else {
+	$self->error( "UNKNOWN DEVICE TYPE: '$self->{mqtt_name}':$self->{mqtt_type}" );
+	return;
+    }
+
+    if( $self->{interface} ) {
+	$self->{interface}->add( $self );
+    } else {
+	foreach $interface ( &mqtt::get_interface_list() ) {
+	    $interface->add( $self );
+	}
+    }
+
+    return $self;
+}
+
+=item C<is_dimmable()>
+
+Returns whether object is dimmable.
+
+=cut
+
+sub is_dimmable {
+    my ( $self ) = @_;
+    if( $self->{mqtt_type} eq 'light' ) {
+	return 1;
+    }
+    return 0;
+}
+
+=item C<level(p_level)>
+
+Stores and returns the objects current on_level as a percentage. If p_level 
+is ON and the device has a defined local_onlevel, the local_onlevel is stored 
+as the numeric level in memory.
+
+Returns [0-100]
+
+=cut
+
+sub level {
+    my ( $self, $p_level ) = @_;
+    #
+    # This is really only valid for light type, but it doesn't hurt for other types
+    #
+    if ( defined $p_level ) {
+        my $level = undef;
+        if ( $p_level eq 'on' ) {
+
+            # set the level based on any locally defined on level
+            $level = $self->local_onlevel if $self->can('local_onlevel');
+
+            # set to 100 if a local on level is not defined
+            $level = 100 unless defined($level);
+        }
+        elsif ( $p_level eq 'off' ) {
+            $level = 0;
+        }
+        elsif ( $p_level =~ /^([1]?[0-9]?[0-9])%?$/ ) {
+            if ( $1 < 1 ) {
+                $level = 0;
+            }
+            else {
+                $level = $1;
+            }
+        }
+        $$self{level} = $level if defined $level;
+    }
+    return $$self{level};
+
+}
+
+
+sub set_object_debug {
+    my( $self, $level ) = @_;
+    $level = 1 if !defined $level;
+    $self->{debug_level} = $level;
+}
+
+sub debug {
+    my( $self, $level, $msg ) = @_;
+    if( $self->{debug_level} >= $level ) {
+	$level = 0;
+    }
+    &mqtt::debug( $self->{interface}, $level, $msg );
+}
+
+sub error {
+    my( $self, $msg ) = @_;
+    &mqtt::error( $self->{interface}, $msg );
+}
+
+sub log {
+    my( $self, $msg ) = @_;
+    &mqtt::log( $self->{interface}, $msg );
+}
+
+sub transmit_mqtt_message {
+    my( $self, $topic, $msg, $retain ) = @_;
+
+    if( !$topic ) {
+	$self->error( $self->get_object_name . " attempting to publish empty topic -- ignoring" );
+	return;
+    }
+    if( $self->{interface} ) {
+	$self->{interface}->publish_mqtt_message( $topic, $msg, $retain );
+    } else {
+	&mqtt::broadcast_mqtt_message( $topic, $msg, $retain );
+    }
+}
+
+sub process_template {
+    my( $self, $template, $value_json, $value ) = @_;
+
+    if( $template ) {
+	$template =~ s/^\{\{value_json\.([a-zA-Z\-_]*)\}\}/\$value_json->\{\1\}/;
+	$template =~ s/^\{\{value_json\[\\?\'?([a-zA-Z\-_]*)\\?\'?\]\}\}/\$value_json->\{\1\}/;
+	if( $template !~ /^\$/ ) {
+	    $self->error( "unable to process template $template" );
+	    return;
+	}
+	$self->debug( 2, "fishing template value out of json with '\$value = $template'" );
+	eval "\$value = $template";
+	if( $@  || !$value_json ) {
+	    $self->error( "Error '$@' applying template '$template' to payload:'$value'" );
+	}
+    }
+    return $value;
+}
+
+sub decode_mqtt_payload {
+    my( $self, $topic, $payload, $retained ) = @_;
+    my $msg;
+    my $value_json;
+    my $value;
+    my $brightness;
+    my $value_on;
+    my $value_off;
+
+    $msg = undef;
+    if( $topic eq $self->{disc_info}->{state_topic} ) {
+	$value_on = $self->{disc_info}->{state_on};
+	$value_off = $self->{disc_info}->{state_off};
+    }
+    $value_on = $self->{disc_info}->{payload_on} if !defined $value_on;
+    $value_off = $self->{disc_info}->{payload_off} if !defined $value_off;
+    $value_on = 'ON' if !defined $value_on;
+    $value_off = 'OFF' if !defined $value_off;
+
+    if( $payload =~ /^\s*{/ ) {
+	eval{ $value_json = decode_json( $payload ) };
+	if( $@  || !$value_json ) {
+	    $self->error( "Error '$@' decoding JSON: $payload" );
+	    return;
+	}
+	$self->debug( 3, "json payload decoded to: \n" . Dumper( $value_json ) );
+    }
+
+    ####
+    # Note that the state_topic and the brightness_state_topic can be the same, and likely are!
+    ####
+
+    if( $topic eq $self->{disc_info}->{state_topic} ) {
+	$value = $self->process_template( $self->{disc_info}->{state_value_template} || $self->{disc_info}->{value_template}, $value_json, $payload );
+    }
+    if( $topic eq $self->{disc_info}->{brightness_state_topic} ) {
+	$brightness = $self->process_template( $self->{disc_info}->{brightness_value_template}, $value_json, $payload );
+	my $brightness_scale = $self->{disc_info}->{brightness_scale} || 255;
+	$brightness = int( $brightness * 100 / $brightness_scale ) . '%';
+    }
+    if( $topic eq $self->{disc_info}->{command_topic} ) {
+	$value = $payload;
+    }
+
+    if( $$self{mqtt_type} eq 'binary_sensor'  ||  $$self{mqtt_type} eq 'sensor' ) {
+	if( $retained ) {
+	    $self->debug( 1, "Retained message ignored for $$self{mqtt_type}:$$self{mqtt_name} device" );
+	    return;
+	}
+    }
+
+    if( $$self{mqtt_type} eq 'light'  ) {
+	if( $self->{disc_info}->{schema} eq 'json' ) {
+	    if( $value_json ) {
+		$self->debug( 3, "Decoded state:$value_json->{state} brightness:$value_json->{brightness}" );
+		if( $value_json->{state} eq $value_on ) {
+		    if( $value_json->{brightness} ) {
+			my $brightness_scale = $self->{disc_info}->{brightness_scale} || 255;
+			$msg = int( $value_json->{brightness} * 100 / $brightness_scale ) . '%';
+		    } else {
+			$msg = 'on';
+		    }
+		} elsif( $value_json->{state} eq $value_off ) {
+		    $msg = 'off';
+		}
+	    }
+	} else {
+	    if( $value eq $value_off ) {
+		$msg = 'off';
+	    } elsif( $brightness ) {
+		$msg = $brightness;
+	    } elsif( $value eq $value_on ) {
+		$msg = 'on';
+	    }
+	}
+    } elsif( $$self{mqtt_type} eq 'switch'
+    ||       $$self{mqtt_type} eq 'scene'
+    ) {
+	$msg = 'on' if $value eq $value_on;
+	$msg = 'off' if $value eq $value_off;
+    } elsif( $$self{mqtt_type} eq 'binary_sensor' ) {
+	if( $value eq $value_on ) {
+	    $msg = 'on';
+	    if( $self->{disc_info}->{off_delay} ) {
+		$msg .= "~$self->{disc_info}->{off_delay}~off";
+	    }
+	} elsif( $value eq $value_off ) {
+	    if( !$self->{disc_info}->{off_delay} ) {
+		$msg = 'off';
+	    } else {
+		# ignore off command if {off_delay} is set -- item will be set off by above set timer
+		return;
+	    }
+	}
+    } elsif( $$self{mqtt_type} eq 'sensor' ) {
+        $msg = $value;
+    } else {
+	$self->error( "Unknown object type '$$self{mqtt_type}' on object '$$self{topic}'" );
+    }
+    if( !$msg ) {
+	$self->error( "Unable to decode mqtt message '$payload'" );
+	# $self->error( Dumper( $self ) );
+    }
+    return $msg;
+}
+
+sub encode_mqtt_payload {
+    my( $self, $setval, $topic ) = @_;
+    my $payload;
+    my $value;
+    my $brightness;
+    my $brightness_scale;
+    my $value_on;
+    my $value_off;
+
+    $payload = undef;
+    if( $topic eq $self->{disc_info}->{state_topic} ) {
+	$value_on = $self->{disc_info}->{state_on};
+	$value_off = $self->{disc_info}->{state_off};
+    }
+    $value_on = $self->{disc_info}->{payload_on} if !defined $value_on;
+    $value_off = $self->{disc_info}->{payload_off} if !defined $value_off;
+    $value_on = 'ON' if !defined $value_on;
+    $value_off = 'OFF' if !defined $value_off;
+
+    $brightness_scale = $self->{disc_info}->{brightness_scale} || 255;
+    my $level;
+    if( $self->{mqtt_type} eq 'light' ) {
+	($level) = $setval =~ /^([1]?[0-9]?[0-9])%?$/;
+    }
+    if( $level ) {
+	if ( $level < 1 ) {
+	    $level = 0;
+	    $value = $value_off;
+	} else {
+	    $value = $value_on;
+	}
+	$brightness = int( ( $level * $brightness_scale / 100 ) + .5 );
+    } elsif( $setval eq 'on' ) {
+	$value = $value_on;
+	$brightness = $brightness_scale;
+    } elsif( $setval eq 'off' ) {
+	$value = $value_off;
+	$brightness = 0;
+    } else {
+	$value = $setval;
+    }
+
+    if( $self->{mqtt_type} eq 'light' ) {
+	if( $self->{disc_info}->{schema} eq 'json' ) {
+	    $payload = "{ \"state\" : \"$value\", \"brightness\" : $brightness }";
+	} else {
+	    if( $topic eq $self->{disc_info}->{command_topic} ) {
+		$payload = $value;
+	    } elsif( $topic eq $self->{disc_info}->{brightness_command_topic} ) {
+		$payload = $brightness;
+	    }
+	}
+    } elsif( $self->{mqtt_type} eq 'switch' 
+    ||       $self->{mqtt_type} eq 'binary_sensor'
+    ||       $self->{mqtt_type} eq 'sensor'
+    ||       $self->{mqtt_type} eq 'scene'
+    ) {
+	$payload = $value;
+    } else {
+	$self->log( "MQTT Error: unknown object type '$$self{mqtt_type}' on object '$$self{mqtt_name}'" );
+    }
+    return $payload;
+}
+
+my $short_name_map = {
+    'act_t' =>               'action_topic',
+    'act_tpl' =>             'action_template',
+    'atype' =>               'automation_type',
+    'aux_cmd_t' =>           'aux_command_topic',
+    'aux_stat_tpl' =>        'aux_state_template',
+    'aux_stat_t' =>          'aux_state_topic',
+    'avty' =>                'availability',
+    'avty_t' =>              'availability_topic',
+    'away_mode_cmd_t' =>     'away_mode_command_topic',
+    'away_mode_stat_tpl' =>  'away_mode_state_template',
+    'away_mode_stat_t' =>    'away_mode_state_topic',
+    'b_tpl' =>               'blue_template',
+    'bri_cmd_t' =>           'brightness_command_topic',
+    'bri_scl' =>             'brightness_scale',
+    'bri_stat_t' =>          'brightness_state_topic',
+    'bri_tpl' =>             'brightness_template',
+    'bri_val_tpl' =>         'brightness_value_template',
+    'clr_temp_cmd_tpl' =>    'color_temp_command_template',
+    'bat_lev_t' =>           'battery_level_topic',
+    'bat_lev_tpl' =>         'battery_level_template',
+    'chrg_t' =>              'charging_topic',
+    'chrg_tpl' =>            'charging_template',
+    'clr_temp_cmd_t' =>      'color_temp_command_topic',
+    'clr_temp_stat_t' =>     'color_temp_state_topic',
+    'clr_temp_tpl' =>        'color_temp_template',
+    'clr_temp_val_tpl' =>    'color_temp_value_template',
+    'cln_t' =>               'cleaning_topic',
+    'cln_tpl' =>             'cleaning_template',
+    'cmd_off_tpl' =>         'command_off_template',
+    'cmd_on_tpl' =>          'command_on_template',
+    'cmd_t' =>               'command_topic',
+    'cmd_tpl' =>             'command_template',
+    'cod_arm_req' =>         'code_arm_required',
+    'cod_dis_req' =>         'code_disarm_required',
+    'curr_temp_t' =>         'current_temperature_topic',
+    'curr_temp_tpl' =>       'current_temperature_template',
+    'dev' =>                 'device',
+    'dev_cla' =>             'device_class',
+    'dock_t' =>              'docked_topic',
+    'dock_tpl' =>            'docked_template',
+    'err_t' =>               'error_topic',
+    'err_tpl' =>             'error_template',
+    'fanspd_t' =>            'fan_speed_topic',
+    'fanspd_tpl' =>          'fan_speed_template',
+    'fanspd_lst' =>          'fan_speed_list',
+    'flsh_tlng' =>           'flash_time_long',
+    'flsh_tsht' =>           'flash_time_short',
+    'fx_cmd_t' =>            'effect_command_topic',
+    'fx_list' =>             'effect_list',
+    'fx_stat_t' =>           'effect_state_topic',
+    'fx_tpl' =>              'effect_template',
+    'fx_val_tpl' =>          'effect_value_template',
+    'exp_aft' =>             'expire_after',
+    'fan_mode_cmd_t' =>      'fan_mode_command_topic',
+    'fan_mode_stat_tpl' =>   'fan_mode_state_template',
+    'fan_mode_stat_t' =>     'fan_mode_state_topic',
+    'frc_upd' =>             'force_update',
+    'g_tpl' =>               'green_template',
+    'hold_cmd_t' =>          'hold_command_topic',
+    'hold_stat_tpl' =>       'hold_state_template',
+    'hold_stat_t' =>         'hold_state_topic',
+    'hs_cmd_t' =>            'hs_command_topic',
+    'hs_stat_t' =>           'hs_state_topic',
+    'hs_val_tpl' =>          'hs_value_template',
+    'ic' =>                  'icon',
+    'init' =>                'initial',
+    'json_attr_t' =>         'json_attributes_topic',
+    'json_attr_tpl' =>       'json_attributes_template',
+    'max_mirs' =>            'max_mireds',
+    'min_mirs' =>            'min_mireds',
+    'max_temp' =>            'max_temp',
+    'min_temp' =>            'min_temp',
+    'mode_cmd_t' =>          'mode_command_topic',
+    'mode_stat_tpl' =>       'mode_state_template',
+    'mode_stat_t' =>         'mode_state_topic',
+    'name' =>                'name',
+    'off_dly' =>             'off_delay',
+    'on_cmd_type' =>         'on_command_type',
+    'opt' =>                 'optimistic',
+    'osc_cmd_t' =>           'oscillation_command_topic',
+    'osc_stat_t' =>          'oscillation_state_topic',
+    'osc_val_tpl' =>         'oscillation_value_template',
+    'pl' =>                  'payload',
+    'pl_arm_away' =>         'payload_arm_away',
+    'pl_arm_home' =>         'payload_arm_home',
+    'pl_arm_custom_b' =>     'payload_arm_custom_bypass',
+    'pl_arm_nite' =>         'payload_arm_night',
+    'pl_avail' =>            'payload_available',
+    'pl_cln_sp' =>           'payload_clean_spot',
+    'pl_cls' =>              'payload_close',
+    'pl_disarm' =>           'payload_disarm',
+    'pl_hi_spd' =>           'payload_high_speed',
+    'pl_home' =>             'payload_home',
+    'pl_lock' =>             'payload_lock',
+    'pl_loc' =>              'payload_locate',
+    'pl_lo_spd' =>           'payload_low_speed',
+    'pl_med_spd' =>          'payload_medium_speed',
+    'pl_not_avail' =>        'payload_not_available',
+    'pl_not_home' =>         'payload_not_home',
+    'pl_off' =>              'payload_off',
+    'pl_off_spd' =>          'payload_off_speed',
+    'pl_on' =>               'payload_on',
+    'pl_open' =>             'payload_open',
+    'pl_osc_off' =>          'payload_oscillation_off',
+    'pl_osc_on' =>           'payload_oscillation_on',
+    'pl_paus' =>             'payload_pause',
+    'pl_stop' =>             'payload_stop',
+    'pl_strt' =>             'payload_start',
+    'pl_stpa' =>             'payload_start_pause',
+    'pl_ret' =>              'payload_return_to_base',
+    'pl_toff' =>             'payload_turn_off',
+    'pl_ton' =>              'payload_turn_on',
+    'pl_unlk' =>             'payload_unlock',
+    'pos_clsd' =>            'position_closed',
+    'pos_open' =>            'position_open',
+    'pow_cmd_t' =>           'power_command_topic',
+    'pow_stat_t' =>          'power_state_topic',
+    'pow_stat_tpl' =>        'power_state_template',
+    'r_tpl' =>               'red_template',
+    'ret' =>                 'retain',
+    'rgb_cmd_tpl' =>         'rgb_command_template',
+    'rgb_cmd_t' =>           'rgb_command_topic',
+    'rgb_stat_t' =>          'rgb_state_topic',
+    'rgb_val_tpl' =>         'rgb_value_template',
+    'send_cmd_t' =>          'send_command_topic',
+    'send_if_off' =>         'send_if_off',
+    'set_fan_spd_t' =>       'set_fan_speed_topic',
+    'set_pos_tpl' =>         'set_position_template',
+    'set_pos_t' =>           'set_position_topic',
+    'pos_t' =>               'position_topic',
+    'spd_cmd_t' =>           'speed_command_topic',
+    'spd_stat_t' =>          'speed_state_topic',
+    'spd_val_tpl' =>         'speed_value_template',
+    'spds' =>                'speeds',
+    'src_type' =>            'source_type',
+    'stat_clsd' =>           'state_closed',
+    'stat_closing' =>        'state_closing',
+    'stat_off' =>            'state_off',
+    'stat_on' =>             'state_on',
+    'stat_open' =>           'state_open',
+    'stat_opening' =>        'state_opening',
+    'stat_locked' =>         'state_locked',
+    'stat_unlocked' =>       'state_unlocked',
+    'stat_t' =>              'state_topic',
+    'stat_tpl' =>            'state_template',
+    'stat_val_tpl' =>        'state_value_template',
+    'stype' =>               'subtype',
+    'sup_feat' =>            'supported_features',
+    'swing_mode_cmd_t' =>    'swing_mode_command_topic',
+    'swing_mode_stat_tpl' => 'swing_mode_state_template',
+    'swing_mode_stat_t' =>   'swing_mode_state_topic',
+    'temp_cmd_t' =>          'temperature_command_topic',
+    'temp_hi_cmd_t' =>       'temperature_high_command_topic',
+    'temp_hi_stat_tpl' =>    'temperature_high_state_template',
+    'temp_hi_stat_t' =>      'temperature_high_state_topic',
+    'temp_lo_cmd_t' =>       'temperature_low_command_topic',
+    'temp_lo_stat_tpl' =>    'temperature_low_state_template',
+    'temp_lo_stat_t' =>      'temperature_low_state_topic',
+    'temp_stat_tpl' =>       'temperature_state_template',
+    'temp_stat_t' =>         'temperature_state_topic',
+    'temp_unit' =>           'temperature_unit',
+    'tilt_clsd_val' =>       'tilt_closed_value',
+    'tilt_cmd_t' =>          'tilt_command_topic',
+    'tilt_inv_stat' =>       'tilt_invert_state',
+    'tilt_max' =>            'tilt_max',
+    'tilt_min' =>            'tilt_min',
+    'tilt_opnd_val' =>       'tilt_opened_value',
+    'tilt_opt' =>            'tilt_optimistic',
+    'tilt_status_t' =>       'tilt_status_topic',
+    'tilt_status_tpl' =>     'tilt_status_template',
+    't' =>                   'topic',
+    'uniq_id' =>             'unique_id',
+    'unit_of_meas' =>        'unit_of_measurement',
+    'val_tpl' =>             'value_template',
+    'whit_val_cmd_t' =>      'white_value_command_topic',
+    'whit_val_scl' =>        'white_value_scale',
+    'whit_val_stat_t' =>     'white_value_state_topic',
+    'whit_val_tpl' =>        'white_value_template',
+    'xy_cmd_t' =>            'xy_command_topic',
+    'xy_stat_t' =>           'xy_state_topic',
+    'xy_val_tpl' =>          'xy_value_template',
+};
+
+sub normalize_discovery_info {
+    my( $disc_info ) = @_;
+
+    # convert short forms to long forms, replace any ~
+    my $topic_subst = $disc_info->{'~'};
+    delete $disc_info->{'~'};
+    foreach my $disc_parm ( keys %{$disc_info} ) {
+	my $longname = $short_name_map->{$disc_parm};
+	if( $longname  &&  $longname ne $disc_parm ) {
+	    $disc_info->{$longname} = $disc_info->{$disc_parm};
+	    delete $disc_info->{$disc_parm};
+	    $disc_parm = $longname;
+	}
+	if( $topic_subst  &&  $disc_parm =~ /^.*_topic$/ ) {
+	    $disc_info->{$disc_parm} =~ s/^~/$topic_subst/;
+	    $disc_info->{$disc_parm} =~ s/~$/$topic_subst/;
+	}
+    }
+}
+
+sub create_discovery_message {
+    my( $self ) = @_;
+
+    #############
+    # Create discovery message, will only be published if $self->{discoverable} is true
+    #############
+
+    &mqtt_BaseItem::normalize_discovery_info( $self->{disc_info} );
+
+    my $msg = {};
+    my $discovery_realm;
+
+    my $disc_topic;
+    my $disc_msg;
+
+    # Note that the discovery topic prefix will be added by the mqtt_Discovery object
+    # when the discovery messages are published
+    if( $self->{realm} ) {
+         $disc_topic = "$self->{disc_type}/$self->{realm}/$self->{disc_info}->{unique_id}/config";
+    } else {
+         $disc_topic = "$self->{disc_type}/$self->{disc_info}->{unique_id}/config";
+    }
+    $disc_msg = encode_json( $self->{disc_info} );
+
+    $self->{disc_topic} = $disc_topic;
+    $self->{disc_msg} = $disc_msg;
+}
+
+# -[ Fini - mqtt_BaseItem ]---------------------------------------------------------
+
+
+# ------------------------------------------------------------------------------
+
+package mqtt_LocalItem;
+
+use strict;
+
+use Data::Dumper;
+
+@mqtt_LocalItem::ISA = ( 'mqtt_BaseItem' );
+
+
+=item C<new(mqtt_interface, name, type, local_object, topic_prefix, discoverable, friendly_name)>
+
+    Creates a MQTT Local Item/object that will publish state information of the local object and respond to mqtt commands for the object
+
+=cut
+
+sub new {     ### mqtt_LocalItem
+    my ( $class, $interface, $name, $type, $local_object, $topicprefix, $discoverable, $friendly_name ) = @_;
+
+    my ($base_type, $device_class) = $type =~ m/^([^:]*):?(.*)$/;
+
+    if( !grep( /$base_type/, ('light','switch','binary_sensor', 'sensor', 'scene' ) ) ) {
+	$interface->error( "Invalid mqtt type '$type'" );
+	return;
+    }
+
+    if( $local_object  &&  !ref $local_object ) {
+	$interface->error( "Invalid local object: $local_object" );
+	return;
+    }
+
+    my ($realm, $mqtt_name) = $topicprefix =~ m|^([^/]+)/([^/]+)$|;
+    my $listen_topic = "$topicprefix/+";
+
+    my $self = new mqtt_BaseItem( $interface, $mqtt_name, $base_type, $listen_topic, $discoverable );
+    return
+      if !$self;
+
+    bless $self, $class;
+
+    $self->{realm} = $realm;
+    $self->debug( 1, "New mqtt_LocalItem( $interface->{instance}, '$mqtt_name', '$type', '$local_object', '$topicprefix', $discoverable, '$friendly_name' )" );
+
+    $self->{disc_info} = {};
+    if( !$friendly_name ) {
+	$friendly_name = $self->{mqtt_name};
+	$friendly_name =~ s/_/ /g;
+    }
+    $self->{disc_info}->{name} = $friendly_name;
+    $self->{disc_info}->{state_topic} = "$topicprefix/state";
+    if( $base_type eq 'light' ) {
+	$self->{disc_info}->{command_topic} = "$topicprefix/level";
+	$self->{disc_info}->{schema} = 'json';
+	$self->{disc_info}->{brightness} = "true";
+	$self->{disc_info}->{brightness_scale} = 100;
+    } elsif( $base_type eq 'switch' ) {
+	$self->{disc_info}->{command_topic} = "$topicprefix/set";
+    } elsif( $base_type eq 'scene' ) {
+	$self->{disc_info}->{command_topic} = "$topicprefix/set";
+	delete $self->{disc_info}->{state_topic};
+    } elsif( $base_type eq 'binary_sensor' ) {
+	$self->{disc_info}->{device_class} = $device_class;
+    } elsif( $base_type eq 'sensor' ) {
+	$self->{disc_info}->{device_class} = $device_class;
+	if( $device_class eq 'temperature' ) {
+	    $self->{disc_info}->{unit_of_measurement} = 'C';
+	}
+    }
+
+    $self->{is_local} = 1;
+
+    if( $local_object ) {
+	# Tie mqtt object to local_object so state changes are sent to mqtt broker
+	$local_object->tie_items($self);
+	$local_object->{mqtt_Local_Item} = $self;
+	$self->{local_item} = $local_object;
+    }
+
+    if( $self->{local_item}  &&  $self->{local_item}->{device_id} ) {
+	$self->{disc_info}->{unique_id} = $self->{realm} . '_' . $self->{local_item}->{device_id};
+	if( $self->{local_item}->{m_group} ) {
+	    $self->{disc_info}->{unique_id} .= $self->{local_item}->{m_group};
+	}
+    } else {
+	$self->{disc_info}->{unique_id} = $self->{realm} . '_' . $self->{mqtt_name};
+	$self->{disc_info}->{unique_id} =~ s/ /_/g;
+    }
+
+    $self->create_discovery_message();
+
+    $Data::Dumper::Maxdepth = 3;
+    $self->debug( 3, "locale item created: \n" . Dumper( $self ) );
+
+    # We may need flags to deal with XML, JSON or Text
+    return $self;
+}
+
+=item C<receive_mqtt_message( topic, message, retained )>
+    Process received mqtt message
+=cut
+
+sub receive_mqtt_message {
+    my ( $self, $topic, $message, $retained ) = @_;
+    my $obj_name;
+
+    ###
+    ### Incoming (MQTT to MH) message for LocalItem
+    ###
+    # Local objects only subscribe to the command topic, all mqtt state messages are ignored
+    # When an mqtt command comes in, the local object is set
+    # If the local object set is successful, it will set the mqtt tied object
+    # The mqtt object will then send out the state message
+
+    if( $self->{local_item} ) {
+	$obj_name = $self->{local_item}->get_object_name();
+    } else {
+	$obj_name = $self->get_object_name();
+    }
+    if( $topic eq $self->{disc_info}->{state_topic} ) {
+	$self->debug( 1, "LocalItem ignoring state topic message" );
+    } elsif( $topic eq $self->{disc_info}->{command_topic} ) {
+	if( $retained ) {
+	    $self->log( "LocalItem received retained command message -- ignoring" );
+	    return;
+	}
+	my $setval = $self->decode_mqtt_payload( $topic, $message, $retained );
+	if( defined $setval ) {
+	    $self->debug( 1, "LocalItem MQTT to MH setting $obj_name::set($setval) based on received message '$message'" );
+	    if( $self->{local_item} ) {
+		$self->{local_item}->set( $setval, $self->{interface} );
+	    } else {
+		$self->SUPER::set( $setval, $self->{interface} );
+	    }
+	}
+    } else {
+        $self->debug( 2, "LocalItem unhandled message T:'$topic'  M:'$message'" );
+    }
+}
+
+=item C<set(state, p_setby, p_response)>
+    Handle local set call
+=cut
+
+sub set {    ### LocalItem
+    my ( $self, $setval, $p_setby, $p_response ) = @_;
+    my $obj_name;
+
+    # This is a locally called set($setval) -- either by the tied local_item or directly called on the object if there is no tied item
+
+    return if &main::check_for_tied_filters( $self, $setval );
+
+    if( $self->{local_item} ) {
+	$obj_name = $self->{local_item}->get_object_name();
+    } else {
+	$obj_name = $self->get_object_name();
+    }
+
+    if( $self->{local_item}  &&  $p_setby ne $self->{local_item} ) {
+	$self->error( "LocalItem $obj_name set($setval) called by other than tied local item -- $p_setby" );
+	return;
+    }
+
+    ###
+    ### Outgoing MH to MQTT for LocalItem
+    ###
+    my $topic = $self->{disc_info}->{state_topic};
+    my $payload = $self->encode_mqtt_payload( $setval, $topic );
+    if( $topic && defined ($payload)  ) {
+	# Note that outgoing state messages are marked to be retained, so that any client can get the latest state info
+	# when it starts up
+	$self->debug( 1, "MH to MQTT LocalItem ${obj_name} set($setval) publishing state message '$payload' to mqtt" );
+	$self->{has_published_state} = 1;
+	$self->transmit_mqtt_message( $topic, $payload, 1 );
+    }
+
+    if( !$self->{local_item} ) {
+	$self->SUPER::set( $setval, $self->{interface} );
+    }
+}
+
+=item C<(publish_current_states( only_unpublished ))>
+    Class function to publish the current states of all local mqtt objects
+
+    If only_unpublished is true, only the current states of objects that have not published
+    their state since MH started will be published.
+
+    This function should be called after the local item states have been restored after
+    startup if there is no initial function that gets current states of local items.
+        For example, INSTEON devices are polled at startup of misterhouse to determine current states
+	This polling will set the state of the local item which will publish to mqtt
+=cut
+
+sub publish_current_states {
+    my( $only_unpublished ) = @_;
+    my $obj;
+    my $msg;
+    my $msg_txt;
+    my $hass_type;
+    my $obj_id;
+
+    &mqtt::log( undef, "Publishing current state data for local objects" );
+    foreach my $interface ( &mqtt::get_interface_list() ) {
+	for my $obj ( @{ $$interface{objects} } ) {
+	    if( $obj->{is_local} ) {
+		if( !$only_unpublished  ||  !$obj->{has_published_state} ) {
+		    my $local_item;
+		    if( $obj->{local_item} ) {
+			$local_item = $obj->{local_item};
+		    } else {
+			$local_item = $obj;
+		    }
+		    my $current_state = $local_item->state;
+		    my $obj_name = $local_item->get_object_name();
+		    if( defined $current_state ) {
+			if( !$local_item->can('is_responder') || $local_item->is_responder ) {
+			    $obj->debug( 1, "setting local object $obj_name to current_state: $current_state" );
+			    $local_item->set( $current_state );
+			} else {
+			    $obj->debug( 1, "object $obj_name is not a responder" );
+			}
+		    } else {
+			$obj->debug( 1, "object $obj_name has no state" );
+		    }
+		}
+	    }
+	}
+    }
+}
+
+# -[ Fini - mqtt_LocalItem ]---------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+
+package mqtt_BaseRemoteItem;
+
+use strict;
+
+use JSON qw( decode_json encode_json );     #
+use Data::Dumper;
+
+@mqtt_BaseRemoteItem::ISA = ( 'mqtt_BaseItem' );
+
+
+=item C<new(mqtt_interface, name, type, listentopic, discoverable )>
+
+    Creates a base MQTT Remote Item.
+    This function does not setup the {disc_info} structure.  That is left up to the child classes.
+
+=cut
+
+sub new {   ### mqtt_BaseRemoteItem
+    my ( $class, $interface, $mqtt_name, $type, $listentopics, $discoverable ) = @_;
+
+    my $self = new mqtt_BaseItem( $interface, $mqtt_name, $type, $listentopics, $discoverable );
+
+    bless $self, $class;
+
+    return $self;
+}
+
+
+=item C<receive_mqtt_message( topic, message, retained)>
+=cut
+
+sub receive_mqtt_message {
+    my ( $self, $topic, $message, $retained ) = @_;
+    ###
+    ### Incoming MQTT to MH message for InstMqttItem
+    ###
+    ### Note that a light object seems to be a superset of a switch so I think
+    ### we can handle the message without testing the mqtt type...
+    ###
+
+    $self->debug( 2, "remote item $self->{object_name} received message R:$retained T:$topic  M:$message" );
+
+    if( $topic eq $self->{disc_info}->{command_topic} 
+    ||  $topic eq $self->{disc_info}->{brightness_command_topic}
+    ||  $topic eq $self->{disc_info}->{color_temp_command_topic}
+    ||  $topic eq $self->{disc_info}->{effect_command_topic}
+    ||  $topic eq $self->{disc_info}->{hs_command_topic}
+    ||  $topic eq $self->{disc_info}->{rgb_command_topic}
+    ||  $topic eq $self->{disc_info}->{white_value_command_topic}
+    ||  $topic eq $self->{disc_info}->{xy_command_topic}
+    ) {
+	$self->debug( 2, "remote item $self->{object_name} ignoring command topic message T:'$topic'" );
+	return;
+    }
+
+    if( $topic eq $self->{disc_info}->{state_topic} 
+    ||  $topic eq $self->{disc_info}->{brightness_state_topic}
+    ) {
+	if( $self->{disc_info}->{optimistic} eq 'true' ) {
+	    $self->debug( 2, "BaseRemoteItem $self->{object_name} ignored state message because device is optimistic" );
+	} else {
+	    my $setval = $self->decode_mqtt_payload( $topic, $message, $retained );
+	    if( $setval ) {
+		$self->debug( 1, "remote item MQTT to MH $$self{mqtt_name} set($setval)" );
+		$self->level( $setval ) if $self->can( 'level' );
+		$self->SUPER::set( $setval, $self->{interface} );
+	    }
+	}
+	return;
+    }
+    if( $topic eq $self->{disc_info}->{availability_topic} ) {
+	if( $message eq $self->{disc_info}->{payload_available} ) {
+	    if( !$retained ) {
+		$self->log( "$self->{object_name} now available" );
+	    }
+	} elsif( $message eq $self->{disc_info}->{payload_not_available} ) {
+	    $self->log( "$self->{mqtt_name} is not available" );
+	    $self->SUPER::set( $message, $self->{interface} );
+	} else {
+	    $self->error( "$self->{object_name} received unrecognized availability message: $message" );
+	}
+	return;
+    }
+
+    $self->debug( 2, "BaseRemoteItem unhandled message T:'$topic'  M:'$message'" );
+}
+
+sub transmit_topic {
+    my ($self, $topicname, $setval) = @_;
+
+    my $obj_name = $self->get_object_name;
+    my $topic = $self->{disc_info}->{$topicname};
+    if( !$topic ) {
+	$self->debug( 2, "BaseRemoteItem $obj_name does not have topic:$topicname -- not publishing" );
+	return;
+    }
+    my $payload = $self->encode_mqtt_payload( $setval, $topic );
+    if( defined $payload ) {
+	$self->debug( 1, "MH to MQTT BaseRemoteItem $obj_name::set($setval) publishing command '$payload' to mqtt" );
+	$self->transmit_mqtt_message( $topic, $payload, 0 );
+    }
+}
+
+
+=item C<set(state, p_setby, p_response)>
+    Handle local set calls
+=cut
+
+sub set {    ### BaseRemoteItem
+    my ( $self, $setval, $p_setby, $p_response ) = @_;
+
+    print( "BaseRemoteItem set($setval) called\n" ) if $main::Debug{set};
+    return if &main::check_for_tied_filters( $self, $setval );
+    print( "BaseRemoteItem set($setval) passed filters\n" ) if $main::Debug{set};
+
+    # Override any set_with_timer requests
+    if ( $$self{set_timer} ) {
+	print( $self->get_object_name . " unsetting timer\n" ) if $main::Debug{set};
+        &Timer::unset( $$self{set_timer} );
+        delete $$self{set_timer};
+    }
+
+    ###
+    ### Outgoing MH to MQTT for BaseRemoteItem
+    ###
+
+    if( $self->{mqtt_type} eq 'light'  &&  $self->{disc_info}->{schema} ne 'json' ) {
+	if( !$self->{disc_info}->{on_command_type}
+	||  $self->{disc_info}->{on_command_type} eq 'last'
+	) {
+	    $self->transmit_topic( 'brightness_command_topic', $setval );
+	    $self->transmit_topic( 'command_topic', $setval );
+	} elsif( $self->{disc_info}->{on_command_type} eq 'first' ) {
+	    $self->transmit_topic( 'command_topic', $setval );
+	    $self->transmit_topic( 'brightness_command_topic', $setval );
+	} elsif( $self->{disc_info}->{on_command_type} eq 'brightness' ) {
+	    $self->transmit_topic( 'brightness_command_topic', $setval );
+	}
+    } else {
+	$self->transmit_topic( 'command_topic', $setval );
+    }
+
+    if( $self->{disc_info}->{optimistic} eq 'true') {
+	$self->level( $setval ) if $self->can( 'level' );
+	$self->SUPER::set( $setval, $p_setby, $p_response );
+    }
+}
+
+=item C<set_with_timer(state, time, return_state, addition_return_states)>
+    Handle local set_with_timer calls
+
+    NOTE:  This timer functionality is required here because the Generic_Item timer
+           is reset by Generic_Item set calls, and the set call for the Generic_Item
+	   in this case is delayed until the state response is received from the mqtt device.
+=cut
+
+sub set_with_timer {
+    my ( $self, $state, $time, $return_state, $additional_return_states ) = @_;
+    return if &main::check_for_tied_filters( $self, $state );
+
+    $self->set($state) unless $state eq '';
+
+    return unless $time;
+
+    my $state_change = ( $state eq 'off' ) ? 'on' : 'off';
+    $state_change = $return_state if defined $return_state;
+    $state_change = $self->{state}
+      if $return_state and lc $return_state eq 'previous';
+
+    $state_change .= ';' . $additional_return_states
+      if $additional_return_states;
+
+    $$self{set_timer} = &Timer::new() unless $$self{set_timer};
+    my $object_name = $self->{object_name};
+    my $action      = "$object_name->set('$state_change')";
+    $$self{set_timer}->set( $time, $action );
+}
+
+
+# -[ Fini - mqtt_BaseRemoteItem ]---------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+
+package mqtt_RemoteItem;
+
+use strict;
+
+use Data::Dumper;
+
+@mqtt_RemoteItem::ISA = ( 'mqtt_BaseRemoteItem' );
+
+
+=item C<new(mqtt_interface, name, type, topicprefix, discoverable, friendly_name)>
+
+    Creates a MQTT RemoteItem/object that will mirror the state of the object, and send commands to it.
+
+=cut
+
+sub make_topic {
+    my ( $prefixfirst, $prefix, $topic, $command ) = @_;
+    if( $prefixfirst ) {
+	return "$prefix/$topic/$command";
+    } else {
+	return "$topic/$prefix/$command";
+    }
+}
+
+sub new {      ### mqtt_RemoteItem
+    my ( $class, $interface, $type, $topicprefix, $discoverable, $friendly_name ) = @_;
+
+    my ($base_type, $device_class) = $type =~ m/^([^:]*):?(.*)$/;
+
+    if( !grep( /$base_type/, ('light','switch') ) ) {
+	$interface->error( "Invalid InstMqttItem type '$type'" );
+	return;
+    }
+
+    my $prefixfirst = 1;
+    my ($prefix, $mqtt_name) = $topicprefix =~ m|^([^/]+)/([^/]+)$|;
+    $prefix = lc( $prefix );
+    if( $prefix && !grep( /$prefix/, ('tele', 'stat', 'cmnd') ) ) {
+	($mqtt_name, $prefix) = $topicprefix =~ m|^([^/]+)/([^/]+)$|;
+	$prefixfirst = 0;
+    }
+    if( !$mqtt_name ) {
+	$interface->error( "Unrecognized topic prefix '$topicprefix'" );
+    }
+
+    my $listen_topic = make_topic( $prefixfirst, '+', $mqtt_name, '+' );
+
+    my $self = new mqtt_BaseRemoteItem( $interface, $mqtt_name, $base_type, $listen_topic, $discoverable );
+
+    return
+      if !$self;
+
+    bless $self, $class;
+
+    $self->debug( 1, "New mqtt_RemoteItem( $interface->{instance}, '$mqtt_name', '$type', '$topicprefix', $discoverable, '$friendly_name' )" );
+
+    $self->{discovered} = 0;
+
+    $self->{disc_info} = {};
+    if( !$friendly_name ) {
+	$friendly_name = $self->{mqtt_name};
+	$friendly_name =~ s/_/ /g;
+    }
+    $self->{disc_info}->{name} = $friendly_name;
+    $self->{disc_info}->{availability_topic} = make_topic( $prefixfirst, 'tele', $mqtt_name, 'LWT' );
+    $self->{disc_info}->{payload_available} = 'Online';
+    $self->{disc_info}->{payload_not_available} = 'Offline';
+    if( $base_type eq 'switch' ) {
+	$self->{disc_info}->{command_topic} = make_topic( $prefixfirst, 'cmnd', $mqtt_name, 'POWER' );
+	$self->{disc_info}->{state_topic} = make_topic( $prefixfirst, 'stat', $mqtt_name, 'POWER' );
+    } elsif( $base_type eq 'light' ) {
+	$self->{disc_info}->{command_topic} = make_topic( $prefixfirst, 'cmnd', $mqtt_name, 'POWER' );
+	$self->{disc_info}->{state_topic} = make_topic( $prefixfirst, 'tele', $mqtt_name, 'STATE' );
+	$self->{disc_info}->{state_value_template} = '{{value_json.POWER}}';
+	$self->{disc_info}->{brightness_state_topic} = make_topic( $prefixfirst, 'tele', $mqtt_name, 'STATE' );
+	$self->{disc_info}->{brightness_value_template} = '{{value_json.Dimmer}}';
+	$self->{disc_info}->{brightness_scale} = 100;
+	$self->{disc_info}->{brightness_command_topic} = make_topic( $prefixfirst, 'cmnd', $mqtt_name, 'Dimmer' );
+	$self->{disc_info}->{on_command_type} = 'brightness';
+    } elsif( $base_type eq 'binary_sensor' ) {
+	# Motion sensor config as defined here: https://blakadder.com/pir-in-tasmota/
+	$self->{disc_info}->{state_topic} = make_topic( $prefixfirst, 'tele', $mqtt_name, 'MOTION' );
+	$self->{disc_info}->{payload_on} = 1;
+	$self->{disc_info}->{device_class} = $device_class;
+	$self->{disc_info}->{force_update} = 'true';
+	$self->{disc_info}->{off_delay} = 30;
+    } elsif( $base_type eq 'sensor' ) {
+	$self->{disc_info}->{state_topic} = make_topic( $prefixfirst, 'tele', $mqtt_name, 'STATE' );
+	$self->{disc_info}->{device_class} = $device_class;
+	$self->{disc_info}->{force_update} = 'true';
+    } else {
+	$self->error( "TasmotaItem type '$type' not supported yet" );
+	return;
+    }
+    $self->{disc_info}->{unique_id} = 'tasmota_' . $self->{mqtt_name};
+    $self->{disc_info}->{unique_id} =~ s/ /_/g;
+
+    $self->create_discovery_message();
+
+    # $Data::Dumper::Maxdepth = 3;
+    # $self->debug( 1, "TasmotaItem created: \n" . Dumper( $self ) );
+
+    # We may need flags to deal with XML, JSON or Text
+    return $self;
+}
+
+# -[ Fini - mqtt_TasmotaItem ]---------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+
+package mqtt_InstMqttItem;
+
+use strict;
+
+use Data::Dumper;
+
+@mqtt_InstMqttItem::ISA = ( 'mqtt_BaseRemoteItem' );
+
+
+=item C<new(mqtt_interface, name, type, topicprefix, discoverable, friendly_name)>
+
+    Creates a MQTT BaseRemoteItem/object that will mirror the state of the object, and send commands to it.
+
+=cut
+
+sub new {      ### mqtt_InstMqttItem
+    my ( $class, $interface, $type, $topicprefix, $discoverable, $friendly_name ) = @_;
+
+    my ($base_type, $device_class) = $type =~ m/^([^:]*):?(.*)$/;
+
+    if( !grep( /$base_type/, ('light','switch','binary_sensor','sensor','scene' ) ) ) {
+	$interface->error( "Invalid InstMqttItem type '$type'" );
+	return;
+    }
+
+    my ($realm, $mqtt_name) = $topicprefix =~ m|^([^/]+)/([^/]+)$|;
+    my $listen_topic = "$topicprefix/+";
+
+    my $self = new mqtt_BaseRemoteItem( $interface, $mqtt_name, $base_type, $listen_topic, $discoverable );
+
+    return
+      if !$self;
+
+    bless $self, $class;
+
+    $self->debug( 1, "New mqtt_InstMqttItem( $interface->{instance}, '$mqtt_name', '$type', '$topicprefix', $discoverable, '$friendly_name' )" );
+
+    $self->{realm} = $realm;
+    $self->{discovered} = 0;
+
+
+    $self->{disc_info} = {};
+    if( !$friendly_name ) {
+	$friendly_name = $self->{mqtt_name};
+	$friendly_name =~ s/_/ /g;
+    }
+    $self->{disc_info}->{name} = $friendly_name;
+    if( $base_type eq 'scene' ) {
+	$self->{disc_info}->{command_topic} = "$realm/modem/scene";
+	$self->{disc_info}->{optimistic} = 'true';
+	$self->{disc_info}->{payload_on} =  "{ \"cmd\" : \"ON\", \"name\" : \"$mqtt_name\" }";
+	$self->{disc_info}->{payload_off} =  "{ \"cmd\" : \"OFF\", \"name\" : \"$mqtt_name\" }";
+    } else {
+	$self->{disc_info}->{state_topic} = "$topicprefix/state";
+	$self->{disc_info}->{command_topic} = "$topicprefix/set";
+	if( $base_type eq 'light' ) {
+	    $self->{disc_info}->{command_topic} = "$topicprefix/level";
+	    $self->{disc_info}->{schema} = 'json';
+	    $self->{disc_info}->{brightness} = "true";
+	} elsif( $base_type eq 'binary_sensor' ) {
+	    $self->{disc_info}->{device_class} = $device_class;
+	} elsif( $base_type eq 'sensor' ) {
+	    $self->{disc_info}->{device_class} = $device_class;
+	}
+    }
+    $self->{disc_info}->{unique_id} = $self->{mqtt_name};
+    $self->{disc_info}->{unique_id} =~ s/ /_/g;
+
+    $self->create_discovery_message();
+
+    # $Data::Dumper::Maxdepth = 3;
+    # $self->debug( 1, "InstMqttItem created: \n" . Dumper( $self ) );
+
+    # We may need flags to deal with XML, JSON or Text
+    return $self;
+}
+
+# -[ Fini - mqtt_InstMqttItem ]---------------------------------------------------------
+
+
+
+# -[ Fini ]---------------------------------------------------------------------
+1;
+


### PR DESCRIPTION
Here it is -- mqtt items and discovery.

I have just submitted a pull request that adds mqtt item support as well as mqtt discovery as defined by
Home Assistant.  Full documentation is found in mqtt_items.pm, but I summarize here.

mqtt_items.pm:
- An mqtt item is a misterhouse object representing the mqtt device,
  managing all messages associated with that device.  
- There are mqtt_RemoteItems for mqtt devices.  The item will receive state messages
  from the device and publish command topics to the device.  This  
  supports Tasmota, IOT4, and likely ESPurna devices
- Also supported are mqtt_LocalItems which are linked to an existing
  misterhouse item and will publish state messages and receive command messages
  for that existing item 
- MQTT LWT messages are also supported for online/offline status as 
  well as other topics such as the brightness topic for dimmable devices.  I have not yet added support for colour lights, but if someone can  point me at a good MH implementation of a light with colour, I will take a look.
- MQTT types supported: switch, light, binary_sensor, sensor
- .mht support for MQTT_REMOTEITEM, MQTT_LOCALITEM and MQTT_INSTMQTT
- MQTT_REMOTEITEMS support Tasmota, IOT4, and likely ESPurna devices
- MQTT_LOCALITEM supports almost any existing mh device that can be mapped to an MQTT type
- MQTT_INSTMQTT supports devices published by the insteon-mqtt project
- These are statically defined MQTT objects, and do not need discovery, but
  defining the objects statically can be tedious.  See discovery below.

mqtt_discovery.pm:
- Discovery allows for the processing of discovery messages as published by
  mqtt devices.  Most mqtt devices have some support for discovery as 
  defined by Home Assistant.  Usually it needs to be turned on on
  the device (eg. Tasmota -- setOption19 1).  
  Misterhouse items are created (mqtt_RemoteItem) for 
  the discovered devices.  These items can be written to a .mht file
  so the next time misterhouse is run, they will appear as first class
  misterhouse items.    
- This module will also publish discovery information for mqtt_LocalItems,
  allowing misterhouse items to be discovered by Home Assistant, or by another
  instance of misterhouse or anything else that can consume discovery messages.
- I have tried this with TASMOTA and IOT4 devices, but it should work
  much more broadly.
- .mht support for MQTT_DISCOVERY class to process discovery messages and
  MQTT_DISCOVERED_ITEM item type for discovered items written to a .mht
  file by mqtt_Discovery::write_discovered_items().
  
mqtt.pm:
- These new modules use the existing broker support in mqtt.pm.  
- I have tried very hard not to break anything in the existing mqtt.pm,
  including the existing mqtt_item class, but there have been some 
  bug fixes and small enhancements made to support the new functionality:
    - multiple mqtt broker support has been fixed.  The code was there,
      but it shared a receive buffer across brokers which didn't work very well :-)
    - enhanced debugging support with debug levels 1-3
    - the ability for an object to listen to a list of topics or topic patterns.
      (thanx Gilles for the topic pattern support!)
    - I had to remove Gilles' short circuit when an object was found matching
      a message topic because there are cases where multiple objects receive the
      same topic
    - optionally unloaded the set function, with the addition of a new object
      method $obj->receive_mqtt_message().  This makes the item code more understandable.
    - added methods for managing retained topics
      
Enjoy.  Open to any and all feedback or suggestions.