### PR TITLE
Allow globs in serial port names.

### DIFF
--- a/lib/Insteon_PLM.pm
+++ b/lib/Insteon_PLM.pm
@@ -81,6 +81,7 @@ sub serial_startup {
     if ( !defined($port) ) {
         main::print_log( "WARN: " . $instance . "_serial_port missing from INI params!" );
     }
+    $port = glob($port);
     my $speed = 19200;
 
     &::print_log("[Insteon_PLM] serial:$port:$speed");


### PR DESCRIPTION
This makes port names like /dev/tty.usbserial-A123BCDE, common on MacOS,
easier to configure and more robust over system and hardware changes.