### PR TITLE
raZberry: Login again after session expires

### DIFF
--- a/lib/raZberry.pm
+++ b/lib/raZberry.pm
@@ -460,6 +460,10 @@ sub process_check {
             main::print_log( "[raZberry:" . $self->{host} . "] ERROR! bad data returned by poll" );
             main::print_log( "[raZberry:" . $self->{host} . "] ERROR! file data is [$file_data]. json data is [$json_data]" );
             $com_status = "offline";
+            if ($file_data =~ /.*Not logged in 401.*/i){
+                $self->{cookie_jar}->clear();
+                $self->login;
+            }
         } else {
             push @process_data, $json_data;
         }
@@ -496,11 +500,15 @@ sub process_check {
 
     #        print "debug: json_data=$json_data\n" if ( $self->{debug} > 2);
             unless ( ($file_data) and ($json_data) ) {
-                main::print_log( "[raZberry:" . $self->{host} . "] ERROR! bad data returned by poll" );
+                main::print_log( "[raZberry:" . $self->{host} . "] ERROR! bad data returned by command" );
                 main::print_log( "[raZberry:" . $self->{host} . "] ERROR! file data is [$file_data]. json data is [$json_data]" );
                 $com_status = "offline";
                 #update the retry on the failed item.
                 $ {$self->{cmd_queue}}[0][3]++;
+                if ($file_data =~ /.*Not logged in 401.*/i){
+                    $self->{cookie_jar}->clear();
+                    $self->login;
+                }
             } else {
                 push @process_data, $json_data;   
                 shift @{ $self->{cmd_queue} }; #successfully processed to remove item from the queue
@@ -511,20 +519,21 @@ sub process_check {
     
 #check for any queued data that needs to be processed $self->{command_timeout}
     if ((scalar @{ $self->{cmd_queue} }) and ($self->{cmd_process}->done() )) {
-        my ($mode, $get_cmd, $time, $retry) = @ { ${ $self->{cmd_queue} }[0] };
-        #print "****        mode=$mode, get_cmd=$get_cmd\n";
+        my ($mode, $url, $time, $retry) = @ { ${ $self->{cmd_queue} }[0] };
+        #print "****        mode=$mode, url=$url\n";
         #print "***         time=$time, time_diff=" . ($main::Time - $time) ." timeout=" .$self->{command_timeout} . " retry=$retry\n";
         #if there is a retry, then execute at request time + (retry * 5 seconds)
         #discard the command if 60 seconds after the request time
         #if the item is queued then wait until at least a second after the request time
         #discard the item if it's been retried $self->{command_timeout_limit} times
         if ($retry > $self->{command_timeout_limit}) {
-            main::print_log( "[raZberry:" . $self->{host} . "] ERROR: Abandoning command $get_cmd due to $retry retry attempts" );
+            main::print_log( "[raZberry:" . $self->{host} . "] ERROR: Abandoning command $url due to $retry retry attempts" );
             shift @{ $self->{cmd_queue}};        
         } elsif (($main::Time - $time) > $self->{command_timeout}) {
-            main::print_log( "[raZberry:" . $self->{host} . "] ERROR: $get_cmd request older than " . $self->{command_timeout} . " seconds. Abandoning request" );
+            main::print_log( "[raZberry:" . $self->{host} . "] ERROR: $url request older than " . $self->{command_timeout} . " seconds. Abandoning request" );
             shift @{ $self->{cmd_queue}}; 
         } elsif (($main::Time > ($time + 1 + ($retry * 5)) and ($self->{cmd_process}->done() ) )) {#the original time isn't a great base for deep queued commands
+            my $get_cmd = $self->get_cmd_string($url);
             if ($retry == 0) {
                 main::print_log( "[raZberry:" . $self->{host} . "] Command Queue found, processing next item" );
             } else {
@@ -763,11 +772,19 @@ sub update_dev {
 }
 
 #------------------------------------------------------------------------------------
+sub get_cmd_string{
+    my ( $self, $url ) = @_;
+    my $cookie = "";
+    $cookie = $self->{cookie_string} if ( $self->{cookie_string} );
+    my $get_params = "-ua ";
+    $get_params .= "-timeout " . $self->{timeout} . " ";
+    $get_params .= "-cookies " . "'" . $cookie . "' " if ($cookie ne "");
+    return "get_url $get_params $url";
+}
+
 sub _get_JSON_data {
     my ( $self, $mode, $cmd ) = @_;
 
-    my $cookie = "";
-    $cookie = $self->{cookie_string} if ( $self->{cookie_string} );
     my $host   = $self->{host};
     my $port   = $self->{port};
     my $params = "";
@@ -782,10 +799,8 @@ sub _get_JSON_data {
         or ( $mode eq "usercode_data" ) );
     $method = "ZWaveAPI" if ( $mode eq "controller" );
     &main::print_log("[raZberry:" . $self->{host} . "]: contacting http://$host:$port/$method/$rest{$mode}$params") if ( $self->{debug} );
-    my $get_params = "-ua ";
-    $get_params .= "-timeout " . $self->{timeout} . " ";
-    $get_params .= "-cookies " . "'" . $cookie . "' " if ($cookie ne "");
-    my $get_cmd = "get_url $get_params " . '"http://' . "$host:$port/$method/$rest{$mode}$params" . '"';
+    my $url = '"http://' . "$host:$port/$method/$rest{$mode}$params" . '"';
+    my $get_cmd = $self->get_cmd_string($url);
 
     if (( $cmd eq "") or ($cmd =~ m/^\?since=/)) { 
         $self->{poll_process}->stop() unless ($self->{poll_process}->done() );
@@ -800,12 +815,12 @@ sub _get_JSON_data {
             $self->{cmd_process}->start();
             $self->{cmd_process_pid}->{ $self->{cmd_process}->pid() } = $mode;    #capture the type of information requested in order to parse;
             $self->{cmd_process_mode} = $mode; 
-            push @{ $self->{cmd_queue} }, [$mode,$get_cmd,$main::Time,0];           
+            push @{ $self->{cmd_queue} }, [$mode,$url,$main::Time,0];
             main::print_log( "[raZberry:" . $self->{host} . "] Backgrounding Command (" . $self->{cmd_process}->pid() . ") command $mode, $get_cmd" ) if ( $self->{debug} );  
         } else {
             main::print_log( "[raZberry:" . $self->{host} . "] Queing Command command $mode, $get_cmd, time " . $main::Time ) if ( $self->{debug} );  
             if (scalar @{ $self->{cmd_queue} } <= $self->{max_cmd_queue} ) {
-                push @{ $self->{cmd_queue} }, [$mode,$get_cmd,$main::Time,0];
+                push @{ $self->{cmd_queue} }, [$mode,$url,$main::Time,0];
             } else {
                 main::print_log( "[raZberry:" . $self->{host} . "] Max Queue Length ($self->{max_cmd_queue}) reached! Discarding queued command" );  
                 #@{ $self->{cmd_queue} } = ();


### PR DESCRIPTION
If the session to z-way expires, a 401-message is receive after sending a
command. This change clears all existing cookies and starts a new login
after 401 was seen.
The internal command queue was change to store only the command URL
instead of the complete command line. The command line is now created
before each request to use always the latest session cookie.

The Issue fixed here can easily be reproduced: 
1. Start misterhouse
2. Go to Z-way Settings -> User Management
3. Select the user misterhouse uses to log into z-way
4. Klick "Logout all sessions"
5. Use misterhouse to send a z-wave command
