### PR TITLE
Always show error message on failed ajax requests

### DIFF
--- a/web/ia7/include/javascript.js
+++ b/web/ia7/include/javascript.js
@@ -2257,9 +2257,15 @@ var ajax_req_error = function(xhr, status, error, module, modal) {
      if (xhr == undefined || xhr.responseText == undefined || xhr.responseText == "") {
          message = "Lost communication with server";
      } else {
-         var data = JSON.parse(xhr.responseText);
          message = "Communication problem with server";
-         if (data !== undefined && data.text !== undefined) message = data.text;
+         try{
+             var data = JSON.parse(xhr.responseText);
+             if (data !== undefined && data.text !== undefined) message = data.text;
+         }
+         catch
+         {
+             message += `: ${xhr.status} - ${xhr.statusText}`;
+         }
      }
      console.log("Ajax Error! module="+module+" status="+status+" error="+error+" msg="+message);
      


### PR DESCRIPTION
If misterhouse is run behind web proxy (tested with nginx), ajax
requests may be answered with an html error page if misterhouse is not
running. In this case no valid JSON is returned. This fix simply catches
the JSON parse exception and adds http status + text to the system
message. Before, the message was never shown because the exception was not
handled.