### PR TITLE
Update mqtt.pm

### DIFF
--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -903,7 +903,7 @@ sub parse_data_to_obj {
 
     $self->debug( 3, "Msg object: " . Dumper( $msg ) );
 
-    if( !$msg->{message} ) {
+    if( !length($msg->{message}) ) {
 	# cleanup message -- ignore
 	return;
     }


### PR DESCRIPTION
As written, mqtt.pm discards any message with a value of 0 or "0".  This change preserves the intention of the coder, but preserves messages that would otherwise be interpreted as "false."