### PR TITLE
mqtt.pm: mask password in debug message, so it doesn't appear in logs

### DIFF
--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -188,6 +188,8 @@ use Data::Dumper;
 
 eval "use bytes";    # Not on all installs, so eval to avoid errors
 
+eval "use Digest::MD5 qw(md5_hex)";    # Not sure if this is on all installs, so eval to avoid errors
+
 # Need to share this with the outside world
 my $msg_id = 1;
 my $blocking_read_timeout = .5;
@@ -448,7 +450,13 @@ sub new {
     $self->debug(1, "    Port       = $$self{port}");
     $self->debug(1, "    Topic      = $$self{topic}");
     $self->debug(1, "    User       = $$self{user_name}");
-    $self->debug(1, "    Password   = $$self{password}");
+    $self->debug(1, "    Password   = " .
+        (
+              exists($INC{'Digest/MD5.pm'})
+            ? "MD5:" . md5_hex($$self{password})
+            : '[masked]'
+	)
+    );
     $self->debug(1, "    Keep Alive = $$self{keep_alive_timer}");
 
     ### ------------------------------------------------------------------------


### PR DESCRIPTION
This is a small fix to mqtt.pm to keep passwords from appearing in clear text in log files, which are in turn backed up nightly, resulting in many, many copies of a clear text password lying around. If Digest::MD5 is available, this change presents the MD5 sum of the password instead of the clear text password.  The developer/user can compare the presented value to "echo -n _password_ | md5sum" if validation is necessary. If Digest::MD5 is unavailable, it replaces the password with the literal "[masked]".