### PR TITLE
Mqtt longer local topics

### DIFF
--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -188,6 +188,8 @@ use Data::Dumper;
 
 eval "use bytes";    # Not on all installs, so eval to avoid errors
 
+eval "use Digest::MD5 qw(md5_hex)";    # Not sure if this is on all installs, so eval to avoid errors
+
 # Need to share this with the outside world
 my $msg_id = 1;
 my $blocking_read_timeout = .5;
@@ -448,7 +450,13 @@ sub new {
     $self->debug(1, "    Port       = $$self{port}");
     $self->debug(1, "    Topic      = $$self{topic}");
     $self->debug(1, "    User       = $$self{user_name}");
-    $self->debug(1, "    Password   = $$self{password}");
+    $self->debug(1, "    Password   = " .
+        (
+              exists($INC{'Digest/MD5.pm'})
+            ? "MD5:" . md5_hex($$self{password})
+            : '[masked]'
+	)
+    );
     $self->debug(1, "    Keep Alive = $$self{keep_alive_timer}");
 
     ### ------------------------------------------------------------------------

--- a/lib/mqtt_items.pm
+++ b/lib/mqtt_items.pm
@@ -99,7 +99,7 @@ Description:
 	        - implements a statically defined mh item for Insteon devices managed
 		  by insteon-mqtt
 		- see https://github.com/TD22057/insteon-mqtt
-		- can pulish HA discovery info, as insteon-mqtt does not implement discovery yet
+		- can publish HA discovery info, as insteon-mqtt does not implement discovery yet
     
 
     Discovery (mqtt_discovery.pm):
@@ -895,9 +895,9 @@ sub new {     ### mqtt_LocalItem
 	return;
     }
 
-    my (@topic_parts) = split( "/", $topicpattern );
+    my (@topic_parts) = split( "/", $topicpattern, 2 );
     my $realm = $topic_parts[0];
-    my $mqtt_name = $topic_parts[1];
+    my $mqtt_name = ($topic_parts[1] =~ s"/[+#]?$""r);	# Remove trailing slash and wildcard, if present.
     my $topic_prefix = "$realm/$mqtt_name";
     my $listen_topic;
     if( $#topic_parts == 1 ) {
@@ -972,7 +972,6 @@ sub new {     ### mqtt_LocalItem
 
     $self->create_discovery_message();
 
-    $Data::Dumper::Maxdepth = 3;
     $self->debug( 3, "locale item created: \n" . Dumper( $self ) );
 
     # We may need flags to deal with XML, JSON or Text
@@ -1452,9 +1451,6 @@ sub new {      ### mqtt_RemoteItem
 
     $self->create_discovery_message();
 
-    # $Data::Dumper::Maxdepth = 3;
-    # $self->debug( 1, "TasmotaItem created: \n" . Dumper( $self ) );
-
     # We may need flags to deal with XML, JSON or Text
     return $self;
 }
@@ -1540,7 +1536,6 @@ sub new {      ### mqtt_InstMqttItem
 
     $self->create_discovery_message();
 
-    # $Data::Dumper::Maxdepth = 3;
     # $self->debug( 1, "InstMqttItem created: \n" . Dumper( $self ) );
 
     # We may need flags to deal with XML, JSON or Text


### PR DESCRIPTION
mqtt_items.pm currently restrict MQTT topic names to three levels, silently dropping levels if necessary. So the state of an Item "porch_light" can be published as "mh/porch_light/state", but not as "ha/mh/porch_light/state". The current code would publish the latter as "ha/mh/state" without warning. I plan to publish a lot of HA stuff from different sources, with different ACLs to keep them from publishing over each other, and I need more levels. This code removes the 3-node topic limit.

I'm a little green on working with Git and GitHub. In my comparison, it appears that this pull is also including prior, unrelated pull requests from Dave N (regarding maxdepth) and myself (regarding masking passwords). Those should be harmless if the prior pull requests are already incorporated in to MASTER, but they're not required. I'm only interested in mqtt_items.pm lines 102, 898, and 900. Please let me know if I need to figure out a way not to have those included.