### PR TITLE
Fully kiosk browser

### DIFF
--- a/lib/FullyKioskBrowser.pm
+++ b/lib/FullyKioskBrowser.pm
@@ -231,7 +231,7 @@ sub handle_mqtt_event {
         $self->SUPER::set('off', $self->{_mqtt});
     }
     elsif ($ev eq "onbatterylevelchanged"
-        && $self->{Battery_Level} ne $json->{level})
+        && $self->{Battery_Level} != int($json->{level}))
     {
         $self->{Battery_Level} = int($json->{level});
         &::print_log("FullyKiosk[$self->{_host}]: battery level now '$self->{Battery_Level}'") if $::Debug{fullykiosk};
@@ -336,7 +336,7 @@ sub handle_request_result {
     if ($last_cmd eq "getDeviceInfo") {
         $self->{_settings}     = $json;
         $self->{_deviceId}     = $json->{deviceId};
-        $self->{Battery_Level} = $json->{batteryLevel};
+        $self->{Battery_Level} = int($json->{batteryLevel});
         my $s = $json->{screenOn} ? 'on' : 'off';
         $self->SUPER::set($s, $by);
 


### PR DESCRIPTION
* FullyKiosBrowser: add command work queue
If commands are issued while another one is still processing, the new
command is queued and executed later. This makes it possible to to add
multiple commands without any command getting aborted.
Eg. changing the volume, let the device say something and then change
the volume back:
```perl
	$Fully->send_request("setAudioVolume&level=70&stream=9");
	$Fully->say("Test 1 2 3", 'en');
	$Fully->send_request("setAudioVolume&level=30&stream=9");
```
* FullyKioskBrowser: Add App_State property
To check wether FullyKiosk is currently the app in use it is now possible to check the
`App_State` property. It is either 'foreground' or 'background'.
(requires mqtt to work)

* treat Battery level as a number 
