### PR TITLE
mh: replace stray "print" with "print_log".

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -4740,7 +4740,7 @@ sub process_external_command {
     $cmd =~ s/^\s+//;                            # Deletes leading blanks
     $cmd =~ s/\s+$//;                            # Deletes trailing blanks
 
-    print "Running external command: $cmd set by $set_by\n"
+    print_log "Running external command: $cmd set by $set_by\n"
       unless $config_parms{no_log} =~ /xcmd/;
 
     if ( &run_voice_cmd( lc($cmd), undef, $set_by, 0, $respond_target ) ) {


### PR DESCRIPTION
Subroutine "process_external_command" has 5 calls to "print_log", plus one to "print". It appears the stray "print" should be a "print_log", and this PR makes that change.