### PR TITLE
some cleanup of the mqtt code

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -1958,10 +1958,10 @@ sub read_table_A {
 	$code .= "\$${object_name} = new mqtt_InstMqttItem( \$${broker}, '$type', '$topicprefix', $discoverable, '$friendly_name' );\n";
     }
     elsif( $type eq "MQTT_DISCOVERY" ) {
-	my ($object_name, $discovery_topic, $broker) = @item_info;
+	my ($object_name, $discovery_topic, $broker, $action) = @item_info;
 	require mqtt_discovery;
 	require mqtt_items;
-	$code .= "\$${object_name} = new mqtt_Discovery( \$${broker}, '$object_name', '$discovery_topic');  #noloop\n";
+	$code .= "\$${object_name} = new mqtt_Discovery( \$${broker}, '$object_name', '$discovery_topic', '$action' );  #noloop\n";
     }
     elsif( $type eq "MQTT_DISCOVEREDITEM" ) {
 	my ($object_name, $disc_name, $disc_topic, $disc_msg ) = $record =~ /MQTT_DISCOVEREDITEM\s*,\s*([^,]+),\s*([^,]+),\s*([^,]+)\,\s*(.*)$/;


### PR DESCRIPTION
Moved some code into the 'right' modules.  Left stubs for backward compatibility.
Enhanced the documentation in the source files.
Cleaned up the debugging information somewhat.
Publish discovery information as each item is created, no need to call publish_discovery_data, although it won't hurt either.
Added some voice commands for general management of the MH and mqtt servers.