### PR TITLE
HA_Item: handle up/down commands for covers

### DIFF
--- a/lib/HA_Item.pm
+++ b/lib/HA_Item.pm
@@ -1469,6 +1469,10 @@ sub ha_set_state {
         } else {
             $service = 'open_cover';
         }
+    } elsif( lc $mode eq 'up'){
+            $service = 'open_cover';
+    } elsif( lc $mode eq 'down'){
+            $service = 'close_cover';
     } elsif( lc $mode eq 'closed' ) {
         $service = 'close_cover';
     } elsif( lc $mode eq 'stop' ) {


### PR DESCRIPTION
for types of 'cover:digital' ia7 ui shows "up" and "down" commands. This handles those and sends open_cover/close_cover as needed.