### PR TITLE
HA_Item: Add items to their groups defined in .mht file

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -1995,6 +1995,9 @@ sub read_table_A {
 	$code .= "\$${object_name} = new HA_Item( '$domain', '$entity', \$$ha_server ";
 	$code .= ",'$options' " if ($options);
 	$code .= ");\n";
+
+        $name = $object_name;
+        $grouplist = $group;
     }
     #-------------- End Home Assistant Objects -----------------
     elsif ( $type =~ /PLCBUS_.*/ ) {


### PR DESCRIPTION
This sets $name and $grouplist which is used way down in read_table_A.pl to add the objects to their groups.