### PR TITLE
Daves fixes

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -355,6 +355,8 @@ EOF
         for (@parms1) {
             push( @parms2, "$1=s" ) if /^([^\s\#\=]+)\s*=/;
         }
+	my %parmsh = map{ $_, 1} @parms2;
+	@parms2 = keys %parmsh;
         use Getopt::Long;
         if ( !&GetOptions( \%config_parms_startup, "h", "help", "run=s", "run_parms=s", @parms2 )
             or ( $config_parms_startup{h} or $config_parms_startup{help} ) )

--- a/lib/AoGSmartHome_Items.pm
+++ b/lib/AoGSmartHome_Items.pm
@@ -212,7 +212,7 @@ package AoGSmartHome_Items;
 @AoGSmartHome_Items::ISA = ('Generic_Item');
 
 use Data::Dumper;
-use Storable;
+use Storable qw(nstore retrieve);
 
 #--------------Logging and debugging functions----------------------------------------
 
@@ -1441,7 +1441,7 @@ sub uuid {
     my $idmap->{'idmap'} = $self->{'idmap'};
 
     my $file = $::config_parms{'data_dir'} . '/aogsmarthome_temp.saved_id';
-    store $idmap, $file;
+    nstore $idmap, $file;
 
     return $highid;
 

--- a/lib/http_server_aog.pl
+++ b/lib/http_server_aog.pl
@@ -33,7 +33,7 @@ B<NONE>
 use Config;
 use MIME::Base64;
 use JSON qw(decode_json);
-use Storable;
+use Storable qw(nstore retrieve);
 use constant RANDBITS => $Config{randbits};
 use constant RAND_MAX => 2**RANDBITS;
 
@@ -271,7 +271,7 @@ EOF
 
             &aog_debug( 1, "token for user '$Authorized' did not exist; generated token '$token'" );
 
-            store $oauth_tokens, $::config_parms{'aog_oauth_tokens_file'};
+            nstore $oauth_tokens, $::config_parms{'aog_oauth_tokens_file'};
         }
 
         return http_redirect("$HTTP_ARGV{'redirect_uri'}#access_token=$token&token_type=bearer&state=$HTTP_ARGV{'state'}");

--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -492,6 +492,7 @@ sub new {
     #  $self->set( 'on', $self );
 
     &::Reload_post_add_hook( \&mqtt::generate_voice_commands, 1, $self );
+    &::Reload_post_add_hook( \&mqtt::create_discovery_data, 1, $self );
 
     return $self;
 }
@@ -1175,6 +1176,7 @@ sub list_retained_topics {
     }
 
     foreach my $interface ( @interface_list ) {
+	$interface->log( "Listing retained topics for: $interface->{instance}" );
 	for my $topic ( keys %{$interface->{retained_topics}} ) {
 	    my $handled = $interface->{retained_topics}->{$topic};
 	    $interface->log( "$$interface{instance} retained topic: ($handled) $topic" );
@@ -1221,6 +1223,29 @@ sub cleanup_discovery_topics {
 }
 
 # ------------------------------------------------------------------------------
+
+=item C<(create_discovery_data())>
+
+Create discovery messages for each discoverable item.
+
+=cut
+
+sub create_discovery_data {
+    my ($self) = @_;
+    my $obj;
+
+    if( !$self->isConnected ) {
+	$self->error( "Unable to publish discovery data -- $self->{instance} not connected" );
+	return 0;
+    }
+    $self->log( "Creating and publishing discovery data for all discoverable objects" );
+    for my $obj ( @{ $self->{objects} } ) {
+	if( $obj->can( 'create_discovery_message' ) ) {
+	    $obj->create_discovery_message();
+	}
+    }
+    return 1;
+}
 
 =item C<(publish_discovery_data())>
 

--- a/lib/mqtt_discovery.pm
+++ b/lib/mqtt_discovery.pm
@@ -114,7 +114,7 @@ sub new {   #### mqtt_DiscoveredItem
 	} else {
 	    $mqtt_type = $disc_type;
 	}
-    } elsif( grep( /^${disc_type}$/, ('light', 'switch', 'binary_sensor', 'sensor', 'scene', 'select') ) ) {
+    } elsif( grep( /^${disc_type}$/, ('light', 'switch', 'binary_sensor', 'sensor', 'scene', 'select', 'text', 'number') ) ) {
 	$mqtt_type = $disc_type;
     } else {
 	$disc_obj->debug( 1, "UNRECOGNIZED DISCOVERY TYPE: $disc_type" );
@@ -185,7 +185,7 @@ sub new {   #### mqtt_DiscoveredItem
     } else {
 	$obj_name .= $device_id;
     }
-    $obj_name =~ s/ /_/g;
+    $obj_name =~ s/[^\w]/_/g;
     $obj = ::get_object_by_name( $obj_name );
     if( $obj ) {
 	$disc_obj->error( "Trying to create object that already exists: $obj_name" );


### PR DESCRIPTION
mh -- eliminate perl warnings on duplicate templates in GetOptions
AoG -- use nstore so aog storage is compatible across perl distributions
mqtt -- added ability to add discovery parameters to mqtt_items and added support for number and text types