### PR TITLE
also remove space befor ',' during parsing of mht files

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -55,7 +55,7 @@ sub read_table_A {
         $other,     $vcommand,   $occupancy, $network,
         $password,  $interface,  $additional_code
     );
-    my (@item_info) = split( ',\s*', $record );
+    my (@item_info) = split( '\s*,\s*', $record );
     my $type = uc shift @item_info;
 
     # -[ ZWave ]----------------------------------------------------------


### PR DESCRIPTION
my HA_items did not update because of an additional space between the ha_entity and the following ','