### PR TITLE
Mqtt alternate topics

### DIFF
--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -1948,21 +1948,24 @@ sub read_table_A {
        
     }
     elsif( $type eq "MQTT_LOCALITEM" ) {
-	my ($local_obj_name, $broker, $type, $topicprefix, $discoverable, $friendly_name);
-	($name, $local_obj_name, $broker, $type, $topicprefix, $discoverable, $friendly_name) = @item_info;
+	# $statetopic and $cmndtopic are optional and have defaults based on $type.
+	my ($local_obj_name, $broker, $type, $topicprefix, $discoverable, $friendly_name, $statetopic, $cmndtopic);
+	($name, $local_obj_name, $broker, $type, $topicprefix, $discoverable, $friendly_name, $statetopic, $cmndtopic) = @item_info;
 	require mqtt_items;
 	if( $broker ) {
 	    $broker = '$' . $broker;
 	} else {
 	    $broker = 'undef';
 	}
-	$code .= "\$${name} = new mqtt_LocalItem( ${broker}, '$name', '$type', \$$local_obj_name, '$topicprefix', $discoverable, '$friendly_name' );\n";
+	$code .= "\$${name} = new mqtt_LocalItem( ${broker}, '$name', '$type', \$$local_obj_name, '$topicprefix', $discoverable, '$friendly_name', '$statetopic', '$cmndtopic' );\n";
     }
     elsif( $type eq "MQTT_REMOTEITEM" ) {
-	my ($broker, $type, $topicprefix, $discoverable, $friendly_name);
-	($name, $grouplist, $broker, $type, $topicprefix, $discoverable, $friendly_name) = @item_info;
+	# $statetopic $cmndtopic are optional and have defaults based on $type.
+	($name, $grouplist) = @item_info;	# Need these to stay in scope, so we can assign groups.
+	my ($broker, $type, $topicprefix, $discoverable, $friendly_name, $statetopic, $cmndtopic);
+	($name, $grouplist, $broker, $type, $topicprefix, $discoverable, $friendly_name, $statetopic, $cmndtopic) = @item_info;
 	require mqtt_items;
-	$code .= "\$${name} = new mqtt_RemoteItem( \$${broker}, '$type', '$topicprefix', $discoverable, '$friendly_name' );\n";
+	$code .= "\$${name} = new mqtt_RemoteItem( \$${broker}, '$type', '$topicprefix', $discoverable, '$friendly_name', '$statetopic', '$cmndtopic');\n";
     }
     elsif( $type eq "MQTT_INSTMQTT" ) {
 	my ($broker, $type, $topicprefix, $discoverable, $friendly_name);


### PR DESCRIPTION
MQTT has no standard topic format, although some formats are more heavily used than others. This PR allows the user to change the topics that MH publishes to/listens to on the MQTT  server, in case the users is required or has conventions that don't match the default ones built into mqtt_items. 

@dave@neudoerffer.com is aware of these changes, has tested them in his home environment, and has voiced no objections.