### PR TITLE
Treat "off_fast" event the same as "off"

### DIFF
--- a/lib/mqtt_items.pm
+++ b/lib/mqtt_items.pm
@@ -735,7 +735,7 @@ sub encode_mqtt_payload {
     } elsif( $setval =~ /^(on|on_fast|100)$/ ) {
 	$value = $value_on;
 	$brightness = $brightness_scale;
-    } elsif( $setval eq 'off' ) {
+    } elsif( $setval =~ /^(off|off_fast|0)$/ ) {
 	$value = $value_off;
 	$brightness = 0;
     } else {


### PR DESCRIPTION
Treat "0" and "off_fast" as synonyms for "off" when publishing the state of a switch. Currently when a switch experiences an "off_fast" event, mqtt_items.pm throws an error instead of publishing that the switch is off. Similar logic is already in place to treat "100" and "on_fast" as synonyms for "on".