### PR TITLE
mqtt.pm: connect to broker with a client-id naming misterhouse insteadd of a Net::MQTT generic ID

### DIFF
--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -280,6 +280,7 @@ sub mqtt_connect() {
     # 20-12-2020 added registration of mqtt Last Will and Testament if defined in mh.ini
     $self->send_mqtt_msg(
         message_type     => MQTT_CONNECT,
+        client_id        => "misterhouse_$$",
         keep_alive_timer => $self->{keep_alive_timer},
 	user_name	 => $self->{user_name},
 	password	 => $self->{password},


### PR DESCRIPTION
Current code does not assign a client-id to our session with the MQTT broker (e.g. mosquitto). This makes the broker log our connection under a Net::MQTT default name, like "NetMQTTpm663 ", which can be hard to identify if other Net::MQTT applications are also connected.

This patch assigns a client-id name of "misterhouse-$$", where $$ is the current process ID. The process ID is included in case a machine is running multiple copies of MH.