### PR TITLE
bin/mh: remove extraneous subroutine call

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -5627,7 +5627,6 @@ sub read_table_files {
                     file     => \$file,	            # Our filename, in case they care
                     format   => \$format,           # The format for that section.
                 );";
-                eval "&$subr_name(\$file, \\\@lines, $section_start+1, $#lines);";
             }
         }
 


### PR DESCRIPTION
Remove an extraneous subroutine call that was left over after a late change to calling arguments. The extraneous call always failed, generating unnecessary log messages, but was otherwise harmless.