### PR TITLE
Mqtt cleanup, Changes to continuation code to better support comments

### DIFF
--- a/bin/mh
+++ b/bin/mh
@@ -5627,7 +5627,6 @@ sub read_table_files {
                     file     => \$file,	            # Our filename, in case they care
                     format   => \$format,           # The format for that section.
                 );";
-                eval "&$subr_name(\$file, \\\@lines, $section_start+1, $#lines);";
             }
         }
 

--- a/lib/HA_Item.pm
+++ b/lib/HA_Item.pm
@@ -412,10 +412,10 @@ sub new {
 
     my @positional_parms = ( 'name', 'address', 'keepalive_time', 'api_key' );
     my @optional_parms = ();
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
 
-    if( !ref $parms ) {
-	HA_Server::error( undef, "HA_Server parameter error: $parms -- item not created" );
+    if( $errstr ) {
+	HA_Server::error( undef, "HA_Server parameter error: $errstr -- item not created" );
 	return;
     }
 
@@ -1183,10 +1183,10 @@ sub new {   # HA_Item
 
     my @positional_parms = ( 'domain', 'ha_entity', 'ha_server:objref', 'options:options' );
     my @option_parms = ( 'primary', 'weatherprimary', 'noweatherupdate', 'no_duplicate_states', 'delay_between_messages:number', 'response_check_delay:number' );
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@option_parms, 1 );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@option_parms, 1 );
 
-    if( !ref $parms ) {
-	HA_Server::error( undef, "HA_Item parameter error: $parms -- item not created" );
+    if( $errstr ) {
+	HA_Server::error( undef, "HA_Item parameter error: $errstr -- item not created" );
 	return;
     }
 

--- a/lib/handy_utilities.pl
+++ b/lib/handy_utilities.pl
@@ -542,16 +542,14 @@ sub main::mht_preprocess_line_continuation {
     #      a continuation line.
     #   2. Continuation lines start with whitespace. The leading whitespace is
     #      removed. Normally, the continuation line is then appended to the 
-    #      primary line. Normally people break lines between items, which
-    #      are comma separated, so the white space is not relevant.
-    #   3. If a user needs to break a line on a non-whitespace character,
-    #      they can indicate this by starting the continuation
-    #      line with whitespace *and* a backslash. Both the leading whitespace and
-    #      the backslash will be removed, and the two lines concatenated without
-    #      any additional space.
-    #   4. Similarly, if a user needs more than one space between their primary
-    #      line and the continuation line, use the backslash again, followed by
-    #      however much additional whitespace they want.
+    #      primary line. People typically break lines between items, where
+    #      whitespace is not significant, so the removed whitespace is not an issue.
+    #   3. If a user needs to break a line on white space and preserve the whitespace,
+    #      they should:
+    #          a. Start the continuation with whitespace, which will be removed.
+    #          b. Then insert a backslash followed by the required amount of 
+    #             whitespace. The backslash will also be removed, but the whitespace
+    #             following the backslash will be retained. See the example below.
     #
     # Steps 3 and 4 permits the remainder to be appended with no intervening space, or
     # with many whitespace characters if they follow the backslash.
@@ -609,9 +607,6 @@ sub main::mht_preprocess_line_continuation {
 
 	# Note that end of comments (including whole line comments), blank lines and
 	# end of line whitespace are all handled in read_table_A
-
-	# Question:  should a blank line terminate the contuation??  If you really
-	#            wanted a blank line, you could use '\'
 
         # Is this a primary line or a continuation line?
         if ($line =~ /^\S/) {

--- a/lib/handy_utilities.pl
+++ b/lib/handy_utilities.pl
@@ -613,12 +613,13 @@ sub main::mht_preprocess_line_continuation {
     foreach my $index ($parms{start}..$parms{stop}) {
         my $linenum = $index + 1;		# For diagnostic messages, etc.
         next if ($parms{arrayref}->[$index] =~ /^(#.*|\s*)$/);		# Ignore blank lines and whole line comments.
-        $parms{arrayref}->[$index] =~ s/\s*#.*//;	# Remove trailing comments. This is what bin/mh does, so we have to match.
+        # $parms{arrayref}->[$index] =~ s/\s*#.*//;	# Remove trailing comments. This is what bin/mh does, so we have to match.
         $parms{arrayref}->[$index] =~ s/\s*$//;	# Remove trailing whitespace.
         my $line = $parms{arrayref}->[$index];
 
         # Skip blank and comment lines.
-        next if ($line =~ /^\s*$/);	# Comment or blank line. No action.
+        next if ($line =~ /^\s*$/);	# blank line. No action.
+        # next if ($line =~ /^\s*#/);	# Comment. No action.
 
         # Is this a primary line or a continuation line?
         if ($line =~ /^\S/) {
@@ -626,22 +627,12 @@ sub main::mht_preprocess_line_continuation {
             $line_start = $index;	# Remember where it starts.
         }
         else {			
-            # It's a continuation line. Append it to the preceding primary line.
-            $line =~ s/^\s*//;		# Remove the leading whitespace.
- 
-            # Now check for a now-leading \ -- indicates not to insert whitespace
-            if ($line =~ /^\\(.*)/) {
-                # Leading backslash. Remove it, and don't prepend a space.
-	        $line = $1;
-            }
-            else {
-                # No leading backslash. Insert one leading space before appending to
-                # the primary line (or a prior continuation line).
-        	$line = " $line";
-            }
-
+            # It's a continuation line.
             # Append this to primary line so far.
-            $parms{arrayref}->[$line_start] .= $line;
+	    # Leave in the newlines, so the end of line comments can be removed properly
+	    #   by split_table_parms.
+
+            $parms{arrayref}->[$line_start] .= "\n$line";
 
             # And delete the continuation line by making it blank.
             $parms{arrayref}->[$index] = '';	# Replace the continuation line with a blank line.
@@ -788,41 +779,135 @@ sub main::parse_arg_string {
 #---------------------------------------------------------------------------
 #   Utility routine to parse mht args from read_table_A.
 #
+sub main::parse_table_debug {
+    my ($str) = @_;
+    if( $main::Debug{table_parms} ) {
+        &main::print_log( $str );
+    }
+}
+
+sub main::split_table_parms {
+    my ($str) = @_;
+    my $parms = [];
+    my $start_pos = 0;
+    my $depth = 0;
+    my $in_json_string = 0;
+    my $in_json = 0;
+    my $in_comment = 0;
+    my $json_escaped = 0;
+    my $strlen = length( $str );
+    my $parmstr;
+
+    main::parse_table_debug( "Splitting table parms str '$str'" );
+
+    # change newlines to carriage return so single char processing is easier
+    $str =~ s/\n/\r/g;
+
+    # Iterate through the string character by character starting from the first {
+    for (my $i = 0; ; $i++) {
+        my $char = substr($str, $i, 1);
+
+	if( (!$in_json && $char eq ',')
+	||  $i == $strlen
+	) {
+	    $parmstr = substr( $str, $start_pos, $i-$start_pos );
+	    $parmstr =~ s/^\s*//;
+	    $parmstr =~ s/\s*$//;
+	    $parmstr =~ s/'/\\'/g;
+	    push @{$parms}, $parmstr;
+	    if( $i == $strlen ) {
+		last;
+	    }
+	    $start_pos = $i + 1;
+	}
+
+	if( $in_comment ) {
+	    substr( $str, $i, 1, ' ' );
+	    if( $char eq "\r" ) {
+		$in_comment = 0;
+	    }
+	    next;
+	}
+	if( !$in_json_string  &&  $char eq '#' ) {
+	    substr( $str, $i, 1, ' ' );
+	    $in_comment = 1;
+	    next;
+	}
+	if( $char eq "\r" ) {
+	    substr( $str, $i, 1, ' ' );
+	    next;
+	}
+	if( !$in_json ) {
+	    if( $char eq '{' ) {
+		$in_json = 1;
+		next;
+	    }
+	} else {
+	    if( $in_json_string  &&  $char eq '\\' ) {
+		$json_escaped = 1;
+		next;
+	    }
+	    if( $json_escaped ) {
+		$json_escaped = 0;
+		next;
+	    }
+	    if( $char eq '"') {
+		$in_json_string = !$in_json_string;
+		next;
+	    }
+	    if( !$in_json_string) {
+		if ($char eq '{') {
+		    $depth++;
+		} elsif ($char eq '}') {
+		    $depth--;
+		    if ($depth < 0) {
+			$in_json = 0; # Found the matching end!
+		    }
+		}
+		next;
+	    }
+	}
+    }
+    main::parse_table_debug( "Split parms returning" . join ',',map {"'$_'"} @{$parms} );
+    return (undef, $parms); 
+}
+
 sub main::parse_table_parms {
     my($args, $positional_parms, $option_parms ) = @_;
-    my $positional_done = 0;
     my $positional_count = scalar @{$positional_parms};
     my $parms = {};
     my $errstr;
+    my $parmstr;
     my $keywords_list = [ @{$positional_parms}, @{$option_parms} ];
 
-    if( $main::Debug{misc} ) {
-        &main::print_log( "Parsing table parms:  " . join ',',@{$args});
-        &main::print_log( "   Keywords_list:  " . join ',',@{$keywords_list});
-    }
-    for( my $i=0; $i < scalar @{$args}; ++$i ) {
-	my $parm = $args->[$i];
+    $parmstr = join ',',@{$args};
+    &main::parse_table_debug( "Parsing table parms:  $parmstr" );
+    &main::parse_table_debug( "   Keywords_list:  " . join ',',@{$keywords_list} );
+    for( my $i=0; ; ++$i ) {
+	my $parm;
 	my $keyword;
 	my $value;
 	my $type;
 
-	$parm =~ s/^'(.*)'/$1/;	# Strip quotes if any.
+	if( $i == scalar @{$args} ) {
+	    last;
+	}
+	$parm = $args->[$i];
+	if( !ref $parm ) {
+	    $parm =~ s/^\s*'(.*)'\s*$/$1/;	# Strip quotes if any.
+	}
+
 	# Check each format, because initially read_table_A quotes, and later it doesn't.
-	if( $parm =~ /=>/ ) {
-	    # $positional_done = 1;
-	    ($keyword,$value) = split(/\s*=>\s*/,$parm,2);
-	} else {
-	    if( !$parm ) {
-		next;
-	    }
-	    #if( $positional_done ) {
-		#return "positional parm '$parm' used after keyword parm(s)";
-	    #}
+	if( !$parm ) {
+	    next;
+	}
+	($keyword,$value) = $parm =~ m/^\s*([^=\{\"\,\s]+)\s*=>\s*(.*)\s*$/;
+	if( !$keyword ) {
 	    if( $i >= $positional_count ) {
-		return "too many positional parameters parm '$parm'";
+		return ("too many positional parameters parm '$parm'");
 	    }
 	    ($keyword, $type) = split( /:/, $positional_parms->[$i] );
-	    $value = $args->[$i];
+	    $value = $parm;
 	    if( $type eq 'options' ) {
 		my @option_list = split( '\|', $value );
 		my $delay;
@@ -834,20 +919,18 @@ sub main::parse_table_parms {
 			$value = 1;
 		    }
 		    $errstr = &main::set_table_parm_value( $parms, $keyword, $value, $keywords_list );
-		    return $errstr if $errstr;
+		    return ($errstr) if $errstr;
 		}
 		$keyword = undef;
 	    }
 	}
 	if( $keyword ) {
 	    $errstr = &main::set_table_parm_value( $parms, $keyword, $value, $keywords_list );
-	    return $errstr if $errstr;
+	    return ($errstr) if $errstr;
 	}
     }
-    if( $main::Debug{misc} ) {
-	&main::print_log( "   Parsed table parms into:  " .  main::table_parms_to_str( $parms ) );
-    }
-    return $parms;
+    &main::parse_table_debug( "   Parsed table parms into:  " .  main::table_parms_to_str( $parms ) );
+    return (undef,$parms);
 }
 
 sub main::set_table_parm_value {
@@ -865,6 +948,13 @@ sub main::set_table_parm_value {
     if( !$type ) {
 	return "unknown parameter '$keyword'";
     }
+    $type = lc( $type );
+
+    &main::parse_table_debug( "   Setting parm '$keyword' to '$value' -- type: $type" );
+
+    if( !ref $value ) {
+	$value =~ s/\s*$//;
+    }
     if( $type eq 'objref' ) {
         if( $value  &&  !ref $value ) {
 	    my $obj;
@@ -881,7 +971,7 @@ sub main::set_table_parm_value {
 	}
     }
     $parms->{$keyword} = $value;
-    return;
+    return undef;
 }
 
 
@@ -919,10 +1009,14 @@ sub main::table_parms_to_str {
 	if( $str ) {
 	    $str .= ', ';
 	}
-	$str .= ${parm} . '=>' . $parms->{$parm};
+	my $value = $parms->{$parm};
+	$value =~ s/\'/\\'/g;
+	$str .= "'${parm} => $value'";
     }
     return $str;
 }
+
+#------------------------------------------------------------------------
 
 sub main::plural {
     my ( $value, $des ) = @_;

--- a/lib/handy_utilities.pl
+++ b/lib/handy_utilities.pl
@@ -542,15 +542,12 @@ sub main::mht_preprocess_line_continuation {
     #      a continuation line.
     #   2. Continuation lines start with whitespace. The leading whitespace is
     #      removed. Normally, the continuation line is then appended to the 
-    #      primary line, separated by a single space. Normally people break 
-    #      lines on whitespace, and since bin/mh automatically removes trailing
-    #      whitespace and we remove the leading whitespace, inserting a space
-    #      is necessary to maintain that break.
-    #   3. If a user needs to break a line on a non-whitespace character, and
-    #      so does not want us to insert a space between the primary and 
-    #      continuation lines, they can indicate this by starting the continuation
+    #      primary line. Normally people break lines between items, which
+    #      are comma separated, so the white space is not relevant.
+    #   3. If a user needs to break a line on a non-whitespace character,
+    #      they can indicate this by starting the continuation
     #      line with whitespace *and* a backslash. Both the leading whitespace and
-    #      the backslash will be removed, and the two line concatenated without
+    #      the backslash will be removed, and the two lines concatenated without
     #      any additional space.
     #   4. Similarly, if a user needs more than one space between their primary
     #      line and the continuation line, use the backslash again, followed by
@@ -574,17 +571,13 @@ sub main::mht_preprocess_line_continuation {
     #      abc def	      # primary line
     #      ghi jkl	      # another primary line
     #
-    #      abc            # primary line.
+    #      abc,           # primary line.
     #          def	      # continuation line.
-    #                     # Yields: "abc def" with a single space.
+    #                     # Yields: "abc,def" with a single space.
     #
-    #      abc            # primary line
-    #          \def       # continuation with leading backslash
-    #                     # Yields: "abcdef"
-    #
-    #      abc            # primary line
-    #          \    def   # continuation that wants much whitespace
-    #                     # Yields: "abc    def"
+    #      abc,           # primary line
+    #          \  def       # continuation with leading backslash
+    #                     # Yields: "abc  def"   (quotes used for clarity only)
     #
     
     # Process the calling args.
@@ -612,14 +605,13 @@ sub main::mht_preprocess_line_continuation {
     my $line_start;
     foreach my $index ($parms{start}..$parms{stop}) {
         my $linenum = $index + 1;		# For diagnostic messages, etc.
-        next if ($parms{arrayref}->[$index] =~ /^(#.*|\s*)$/);		# Ignore blank lines and whole line comments.
-        # $parms{arrayref}->[$index] =~ s/\s*#.*//;	# Remove trailing comments. This is what bin/mh does, so we have to match.
-        $parms{arrayref}->[$index] =~ s/\s*$//;	# Remove trailing whitespace.
         my $line = $parms{arrayref}->[$index];
 
-        # Skip blank and comment lines.
-        next if ($line =~ /^\s*$/);	# blank line. No action.
-        # next if ($line =~ /^\s*#/);	# Comment. No action.
+	# Note that end of comments (including whole line comments), blank lines and
+	# end of line whitespace are all handled in read_table_A
+
+	# Question:  should a blank line terminate the contuation??  If you really
+	#            wanted a blank line, you could use '\'
 
         # Is this a primary line or a continuation line?
         if ($line =~ /^\S/) {
@@ -630,7 +622,7 @@ sub main::mht_preprocess_line_continuation {
             # It's a continuation line.
             # Append this to primary line so far.
 	    # Leave in the newlines, so the end of line comments can be removed properly
-	    #   by split_table_parms.
+	    #   by read_table_A and split_table_parms.
 
             $parms{arrayref}->[$line_start] .= "\n$line";
 
@@ -780,9 +772,9 @@ sub main::parse_arg_string {
 #   Utility routine to parse mht args from read_table_A.
 #
 sub main::parse_table_debug {
-    my ($str) = @_;
-    if( $main::Debug{table_parms} ) {
-        &main::print_log( $str );
+    my ($level, $str) = @_;
+    if( $level <= $main::Debug{table_parms} ) {
+        &main::print_log( "[PARSE]: $str" );
     }
 }
 
@@ -798,7 +790,7 @@ sub main::split_table_parms {
     my $strlen = length( $str );
     my $parmstr;
 
-    main::parse_table_debug( "Splitting table parms str '$str'" );
+    main::parse_table_debug( 2, "Splitting table parms str '$str'" );
 
     # change newlines to carriage return so single char processing is easier
     $str =~ s/\n/\r/g;
@@ -868,7 +860,7 @@ sub main::split_table_parms {
 	    }
 	}
     }
-    main::parse_table_debug( "Split parms returning" . join ',',map {"'$_'"} @{$parms} );
+    main::parse_table_debug( 2, "Split parms returning: " . join ',',map {"'$_'"} @{$parms} );
     return (undef, $parms); 
 }
 
@@ -881,8 +873,8 @@ sub main::parse_table_parms {
     my $keywords_list = [ @{$positional_parms}, @{$option_parms} ];
 
     $parmstr = join ',',@{$args};
-    &main::parse_table_debug( "Parsing table parms:  $parmstr" );
-    &main::parse_table_debug( "   Keywords_list:  " . join ',',@{$keywords_list} );
+    &main::parse_table_debug( 1, "Parsing table parms:  $parmstr" );
+    &main::parse_table_debug( 1, "   Keywords_list:  " . join ',',@{$keywords_list} );
     for( my $i=0; ; ++$i ) {
 	my $parm;
 	my $keyword;
@@ -929,7 +921,7 @@ sub main::parse_table_parms {
 	    return ($errstr) if $errstr;
 	}
     }
-    &main::parse_table_debug( "   Parsed table parms into:  " .  main::table_parms_to_str( $parms ) );
+    &main::parse_table_debug( 2, "   Parsed table parms into:  " .  main::table_parms_to_str( $parms ) );
     return (undef,$parms);
 }
 
@@ -950,7 +942,7 @@ sub main::set_table_parm_value {
     }
     $type = lc( $type );
 
-    &main::parse_table_debug( "   Setting parm '$keyword' to '$value' -- type: $type" );
+    &main::parse_table_debug( 1, "   Setting parm '$keyword' to '$value' -- type: $type" );
 
     if( !ref $value ) {
 	$value =~ s/\s*$//;

--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -91,7 +91,7 @@ Example initialization:
     Alternatively, all parameters after the instance name can be named in a "keyword=>value" format. Valid 
     keywords are:
 
-        host, port, topic, user, password, keepalive_time, use_ha_device_discovery, topic_prefix
+        host, port, topic, user, password, keepalive_time, topic_prefix
 
     Example:
 
@@ -208,6 +208,8 @@ use Time::HiRes;
 
 use Data::Dumper;
 
+use JSON qw( decode_json encode_json );     #
+
 eval "use bytes";    # Not on all installs, so eval to avoid errors
 
 eval "use Digest::MD5 qw(md5_hex)";    # Not sure if this is on all installs, so eval to avoid errors
@@ -229,6 +231,7 @@ sub dump() {
 sub log {
     my ($self, $str, $prefix) = @_;
     my $maxlength = 300;
+    my $cont_lines = 0;
 
     $prefix = $prefix || '[MQTT]: ';
     while( length( $str ) > $maxlength ) {
@@ -237,14 +240,23 @@ sub log {
 	for( $i=0; $i<length($str) && $l<$maxlength; ++$i,++$l ) {
 	    if( substr( $str, $i, 1 ) eq "\n" ) {
 		$l = 0;
+		$cont_lines = 0;
 	    }
 	}
+	if( $l == $maxlength ) {
+	    ++$cont_lines;
+	}
 	&main::print_log( $prefix . substr($str,0,$i) );
+	if( $cont_lines == 2 ) {
+	    $str = '<truncated>';
+	    last;
+	}
+
 	$str = substr( $str, $i );
 
 	# 2024-12: After first pass, add '....  ' once to indicate cont. line. Keep the
 	# original prefix so any log scanning programs have context. -BPM
-	$prefix .= '....  ' if ($prefix !~ /\.\.\.\.  $/);
+	$prefix = $prefix . '....  ' if ($prefix !~ /\.\.\.\.  $/);
     }
     &main::print_log( $prefix . $str );
 }
@@ -263,6 +275,39 @@ sub error {
 }
 
 # ------------------------------------------------------------------------------
+
+=item <mqtt_subscribe()>
+=cut
+
+sub mqtt_subscribe() {
+    my ($self) = @_;
+    my $msg;
+
+    ### 4) Send a subscribe '#' (we'll have many of these, one for each device)
+    ###    I don't know if this is a good idea or not but that's what I intend to do for now
+    $self->send_mqtt_msg(
+        message_type => MQTT_SUBSCRIBE,
+        message_id   => $msg_id++,
+	cleanSession => 'true',
+        topics       => [ map { [ $_ => MQTT_QOS_AT_MOST_ONCE ] } $self->{topic} ]
+    );
+
+    ### 5) Check for ACK or fail
+    $msg = $self->read_mqtt_msg( $blocking_read_timeout );
+    if( !$msg ) {
+        $self->log( "$$self{instance} Received: " . "No subscription Ack" );
+    }
+    if ( $main::Debug{mqtt} ) {
+        my $s =
+          defined( $$msg{string} )
+          ? "($$msg{string})"
+          : '(--No $$msg{string}--)';
+        ###
+        ### IF we're not getting $$msg{string} then what are we getting ?
+        ###
+        $self->log( "$$self{instance} Subscription 1 ($$self{topic}) acknowledged: " . "$s" );    # @FIXME: Use of uninitialized value
+    }
+}
 
 =item <mqtt_connect()>
 =cut
@@ -324,29 +369,8 @@ sub mqtt_connect() {
     # We should actually get a SubAck but who is checking (yes, I know I should)
     $self->debug( 1, "$$self{instance} Received: " . $msg->string );
 
-    ### 4) Send a subscribe '#' (we'll have many of these, one for each device)
-    ###    I don't know if this is a good idea or not but that's what I intend to do for now
-    $self->send_mqtt_msg(
-        message_type => MQTT_SUBSCRIBE,
-        message_id   => $msg_id++,
-        topics       => [ map { [ $_ => MQTT_QOS_AT_MOST_ONCE ] } $self->{topic} ]
-    );
-
-    ### 5) Check for ACK or fail
-    $msg = $self->read_mqtt_msg( $blocking_read_timeout );
-    if( !$msg ) {
-        $self->log( "$$self{instance} Received: " . "No subscription Ack" );
-    }
-    if ( $main::Debug{mqtt} ) {
-        my $s =
-          defined( $$msg{string} )
-          ? "($$msg{string})"
-          : '(--No $$msg{string}--)';
-        ###
-        ### IF we're not getting $$msg{string} then what are we getting ?
-        ###
-        $self->log( "$$self{instance} Subscription 1 ($$self{topic}) acknowledged: " . "$s" );    # @FIXME: Use of uninitialized value
-    }
+    ### 4,5) subscribe and receive ack
+    $self->mqtt_subscribe();
 
     ### 6) check for data
     $self->debug( 1, "$$self{instance} Initializing MQTT connection ...");
@@ -389,11 +413,11 @@ sub new {
     my ($class, @parmslist) = @_;
 
     my @positional_parms = qw (name host port topic username password keepalive_time);
-    my @optional_parms = qw (topic_prefix use_ha_device_disc);
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    my @optional_parms = qw (topic_prefix);
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
 
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing mqtt(MQTT_BROKER) parameters: $parms -- mqtt broker object not created" );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing mqtt(MQTT_BROKER) parameters: $errstr -- mqtt broker object not created" );
 	return;
     }
 
@@ -405,7 +429,6 @@ sub new {
     my $username	    = $parms->{username};
     my $password	    = $parms->{password};
     my $keepalive	    = $parms->{keepalive_time};
-    my $use_ha_device_disc  = $parms->{user_ha_device_disc};
     my $topic_prefix	    = $parms->{topic_prefix};
 
     if( !defined( $main::Debug{mqtt} ) ) {
@@ -483,15 +506,12 @@ sub new {
     $$self{host}		= $host;
     $$self{port}		= $port;
     $$self{topic}		= $topic;
+    $$self{ignore_topics}	= [];
     $$self{user_name}		= $username;
     $$self{password}		= $password;
     $$self{keep_alive_timer}	= $keepalive;
-    $$self{use_ha_device_disc}	= 0;
 
     #
-    if (defined($use_ha_device_disc) ) {
-    	$$self{use_ha_device_disc} = $use_ha_device_disc;
-    }
     if (defined($topic_prefix)) {
 	$$self{topic_prefix} = $topic_prefix;
     }
@@ -521,7 +541,6 @@ sub new {
 	)
     );
     $self->debug(1, "    Keep Alive             = $$self{keep_alive_timer}");
-    $self->debug(1, "    Use HA Device Discovery= $$self{use_ha_device_disc}");
     $self->debug(1, "    Topic Prefix           = $$self{topic_prefix}");
 
     ### ------------------------------------------------------------------------
@@ -617,8 +636,7 @@ sub check_for_data {
                 ###
                 ### Someone published something, deal with it
                 ###
-		$self->debug( 1, "$inst Rcv'd: R:$$msg{retain} T:'$$msg{topic}' M:'$$msg{message}'"  );
-		# $self->debug( 1, "$inst Rcv'd: S:'" . $msg->string . "'", 3 );
+		$self->debug( 1, "$inst Rcv'd: R:$msg->{retain} T:'$msg->{topic}' M:'$msg->{message}'"  );
 
                 ###
                 ### So we want the topic and the message
@@ -962,6 +980,52 @@ sub remove_item {
 
 # ------------------------------------------------------------------------------
 
+=item C<(add_ignore_topic)>
+=cut
+
+sub add_ignore_topic {
+    my ( $self, $topic ) = @_;
+
+    push @{$self->{ignore_topics}}, $topic;
+    $self->log( "$self->{instance} ignoring topic '$topic'" );
+}
+
+# ------------------------------------------------------------------------------
+
+sub topic_match {
+    my ($self, $topic, $pattern) = @_;
+    my $orig_pattern = $pattern;
+    my $counter;
+
+    # check if this pattern has wildcard chars, and if so replace the wildcard characters
+    # with the corresponding pieces from the topic
+    if (   index( $pattern, "\+" ) >= 0
+	|| index( $pattern, "\#" ) >= 0 )
+    {
+	my @split_topic = split( "/", $topic );
+	my @split_pattern   = split( "/", $pattern );
+	$counter        = 0;
+	foreach (@split_pattern) {
+	    if ( $split_pattern[$counter] eq "+"  &&  defined $split_topic[$counter] ) {
+		$pattern =~ s/\+/$split_topic[$counter]/;
+	    }
+	    if ( $split_pattern[$counter] eq "#" ) {
+		if( index( $pattern, '#' ) < length( $topic ) ) {
+		    $pattern = substr( $pattern, 0, index( $pattern, "#" ) ) . substr( $topic, index( $pattern, "#" ) );
+		}
+		last;
+	    }
+	    $counter++;
+	}
+    }
+
+    # the edited pattern is now ready to compare with the topic
+    if ( $pattern eq $topic ) {
+	return 1;
+    }
+    return 0;
+}
+
 =item C<parse_data_to_obj()>
     Take the data and parse it to the MH obj()
 
@@ -981,13 +1045,25 @@ sub remove_item {
 
 sub parse_data_to_obj {
     my ( $self, $msg, $p_setby ) = @_;
+    my $pattern;
 
     $self->debug( 3, "Msg object: " . Dumper( $msg ) );
 
-    if( !length($msg->{message}) && $msg->{retain} ) {
+    if( !length($msg->{message}) ) {
 	# cleanup message -- ignore
+	delete $self->{retained_topics}->{$msg->{topic}};
+	$self->debug( 2, "DELETING RETAINED TOPIC '$msg->{topic}'" );
 	return;
     }
+
+    # Check if topic matches any ignore_topics
+    for $pattern (@{$self->{ignore_topics}}) {
+	if( $self->topic_match( $msg->{topic}, $pattern ) ) {
+	    $self->debug( 1, "topic '$msg->{topic}' ignored" );
+	    return;
+	}
+    }
+
 
     # 20-12-2020 added support for wildcard mqtt devices e.g. in items.mht
     # MQTT_DEVICE, MQTT_test_wildcard, , mqtt_1, tele/+/LWT
@@ -996,9 +1072,7 @@ sub parse_data_to_obj {
     # NOTE, use of multi level wildcards can consume a lot of CPU
     # it also exits the loop if it finds a match for speed when there is a large number of mqtt devices
 
-    my ( @split_incoming, @split_device, $counter, $device_topic, $message_handled );
-    #
-    $message_handled = 0;
+    my $message_handled = 0;
     for my $obj ( @{ $$self{objects} } ) {
 	# 2021/2/4 -- added support for a mqtt object to listen for a list of topics
 	my @topiclist;
@@ -1007,31 +1081,10 @@ sub parse_data_to_obj {
 	} else {
 	    @topiclist = ( $obj->{topic} );
 	}
-        for $device_topic (@topiclist) {
+        for $pattern (@topiclist) {
 	    # check if this mqtt device is a wildcard, and if so replace the wildcard characters
 	    # with the incoming message topic pieces
-	    if (   index( $device_topic, "\+" ) >= 0
-		|| index( $device_topic, "\#" ) >= 0 )
-	    {
-		@split_incoming = split( "/", $msg->{topic} );
-		@split_device   = split( "/", $device_topic );
-		$counter        = 0;
-		foreach (@split_device) {
-		    if ( $split_device[$counter] eq "+"  &&  defined $split_incoming[$counter] ) {
-			$device_topic =~ s/\+/$split_incoming[$counter]/;
-		    }
-		    if ( $split_device[$counter] eq "#" ) {
-			if( index( $device_topic, '#' ) < length( $msg->{topic} ) ) {
-			    $device_topic = substr( $device_topic, 0, index( $device_topic, "#" ) ) . substr( $$msg{topic}, index( $device_topic, "#" ) );
-			}
-			last;
-		    }
-		    $counter++;
-		}
-	    }
-    
-	    # the edited device topic is now ready to compare with the incoming message topic
-	    if ( $device_topic eq $msg->{topic} ) {
+	    if( $self->topic_match( $msg->{topic}, $pattern ) ) {
 		if( $obj->can( 'receive_mqtt_message' ) ) {
 		    $obj->receive_mqtt_message( $msg->{topic}, $msg->{message}, $msg->{retain} );
 		} else {
@@ -1063,7 +1116,7 @@ sub generate_voice_commands {
         my $object_string;
         my $object_name = $self->get_object_name;
         $self->{init_v_cmd} = 1;
-        &main::print_log("Generating Voice commands for MQTT Server $object_name");
+        $self->log( "Generating Voice commands for MQTT Server $object_name" );
 
         my $voice_cmds = $self->get_voice_cmds();
         my $i          = 1;
@@ -1119,11 +1172,12 @@ sub get_voice_cmds {
 	);
     my %voice_cmds = (
         "$command -- List retained topics"  => "${object_name}->list_retained_topics()",
-        "$command -- Publish discovery data"  => "${object_name}->publish_discovery_data()",
-        "$command -- Publish current states of local items"  => "${object_name}->publish_current_states()",
         "$command -- Cleanup published info and republish"  => "${object_name}->cleanup_published_topics()",
         "$command -- Cleanup only discovery info and republish"  => "${object_name}->cleanup_discovery_topics()",
         "$command -- Cleanup all retained topics on mqtt server and republish (BE CAREFUL)"  => "${object_name}->cleanup_all_retained_topics()",
+        "$command -- Publish discovery data"  => "${object_name}->publish_discovery_data()",
+        "$command -- Publish current states of local items"  => "${object_name}->publish_current_states()",
+        "$command -- Resubscribe to mqtt topics"  => "${object_name}->mqtt_subscribe()",
 #         'List [all,active,inactive] ' . $command . ' objects to the print log'   => $self->get_object_name . '->print_object_list(SAID)',
 #         "Print $objects $command attributes to the print log"             => "${object_name}->print_object_attrs(SAID)",
     );
@@ -1158,6 +1212,7 @@ sub get_interface_list {
     for my $inst (keys %MQTT_Data) {
 	push @interfaces, $MQTT_Data{$inst}{self};
     }
+    @interfaces = sort {$a->get_object_name() cmp $b->get_object_name() } @interfaces;
     return ( @interfaces );
 }
 
@@ -1172,7 +1227,7 @@ This function is used to delete retained topics from the broker.  It will
 publish an empty message to all retained topics matching a pattern in the
 pattern list that misterhouse has received from this broker.
 
-Using the pattern '.*' will remove all retained topics.  BE CAREFUL.  This will
+Using the pattern '.*' will remove all retained topics.  **BE CAREFUL**.  This will
 remove all retained topics whether you published them or not.  Thus discovery
 messages and current state messages for all mqtt objects in your system will
 be deleted from the mqtt server. Pretty much all mqtt devices will eventually
@@ -1257,8 +1312,7 @@ sub cleanup_all_retained_topics {
     my ($self) = @_;
 
     $self->cleanup_retained_topics( '.*' );
-    $self->publish_discovery_data();
-    $self->publish_current_states();
+    &main::run_after_delay( 2, "\$" . $self->{instance} . "->publish_all_data()" );
 }
 
 =item C<(cleanup_published_topics())>
@@ -1285,8 +1339,7 @@ sub cleanup_published_topics {
 	    $self->cleanup_retained_topics( "$obj->{node_id}/.*" );
 	}
     }
-    $self->publish_discovery_data();
-    $self->publish_current_states();
+    &main::run_after_delay( 2, "\$" . $self->{instance} . "->publish_all_data()" );
 }
 
 =item C<(cleanup_discovery_topics())>
@@ -1308,8 +1361,7 @@ sub cleanup_discovery_topics {
 	    $self->cleanup_retained_topics( "$self->{discovery_prefix}/.*/$obj->{node_id}/.*" );
 	}
     }
-    $self->publish_discovery_data();
-    $self->publish_current_states();
+    &main::run_after_delay( 2, "\$" . $self->{instance} . "->publish_all_data()" );
 }
 
 # ------------------------------------------------------------------------------
@@ -1390,6 +1442,18 @@ sub publish_current_states {
     }
 }
 
+=item C<(publish_all_data( only_unpublished ))>
+    Function to publish the discovery info and current states of all local mqtt objects for this mqtt server
+=cut
+
+sub publish_all_data {
+    my( $self, $only_unpublished ) = @_;
+
+    $self->publish_discovery_data( $only_unpublished );
+    $self->publish_current_states( $only_unpublished );
+    &main::run_after_delay( 3, "\$" . $self->{instance} . "->mqtt_subscribe()" );
+}
+
 =item C<write_discovered_items(filename, autoupdate)>
 
     Writes out all mqtt items that have been discovered to a .mqt file.
@@ -1433,7 +1497,10 @@ sub write_discovered_items {
 		my $disc_obj_name = $obj->{disc_interface}->get_object_name;
 		$obj_name =~ s/^\$//;
 		$disc_obj_name =~ s/^\$//;
-		print {$f} "MQTT_DISCOVEREDITEM, $obj_name, $disc_obj_name, $obj->{disc_topic}, $obj->{disc_msg}\n\n";
+		my $disc_text = JSON->new->pretty->canonical->encode( $obj->{disc} );
+		$disc_text =~ s/^/    /;
+		$disc_text =~ s/\n/\n    /g;
+		print {$f} "MQTT_DISCOVEREDITEM, $obj_name, $disc_obj_name, $obj->{disc_topic}, \n$disc_text\n\n";
 	    }
 	}
     }
@@ -1571,10 +1638,10 @@ sub new {
 
     my @positional_parms = qw (broker:objref topic qos retain);
     my @optional_parms = ();
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
 
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing mqtt(MQTT_BROKER) parameters: $parms -- mqtt broker object not created" );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing mqtt(MQTT_BROKER) parameters: $errstr -- mqtt broker object not created" );
 	return;
     }
 

--- a/lib/mqtt.pm
+++ b/lib/mqtt.pm
@@ -529,10 +529,10 @@ sub new {
     $MQTT_Data{$name}{self} = $self;
 
     $self->debug(1, "Opening MQTT ($name) connection to $$self{host}/$$self{port}/$$self{topic}");
-    $self->debug(1, "    Host       = $$self{host}");
-    $self->debug(1, "    Port       = $$self{port}");
-    $self->debug(1, "    Topic      = $$self{topic}");
-    $self->debug(1, "    User       = $$self{user_name}");
+    $self->debug(1, "    Host       = " . ($$self{host}//'[undef]') );
+    $self->debug(1, "    Port       = " . ($$self{port}//'[undef]') );
+    $self->debug(1, "    Topic      = " . ($$self{topic}//'[undef]') );
+    $self->debug(1, "    User       = " . ($$self{user_name}//'[undef]') );
     $self->debug(1, "    Password   = ***" .
         (
               exists($INC{'Digest/MD5.pm'})
@@ -540,8 +540,8 @@ sub new {
             : '[masked]'
 	)
     );
-    $self->debug(1, "    Keep Alive             = $$self{keep_alive_timer}");
-    $self->debug(1, "    Topic Prefix           = $$self{topic_prefix}");
+    $self->debug(1, "    Keep Alive             = " . ($$self{keep_alive_timer}//'[undef]'));
+    $self->debug(1, "    Topic Prefix           = " . ($$self{topic_prefix}//'[undef]'));
 
     ### ------------------------------------------------------------------------
     $self->mqtt_connect();

--- a/lib/mqtt_discovery.pm
+++ b/lib/mqtt_discovery.pm
@@ -64,11 +64,11 @@ use mqtt_items;
 sub new {   #### mqtt_DiscoveredItem
     my ( $class, @parmslist ) = @_;
 
-    my @positional_parms = qw( disc_broker:objref name disc_topic disc_message );
+    my @positional_parms = qw( disc_broker:objref name disc_topic disc_message:json );
     my @optional_parms = qw();
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing MQTT_DISCOVERYITEM parameters: $parms -- mqtt discoveryitem not created" );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing MQTT_DISCOVERYITEM parameters: $errstr -- mqtt discoveryitem not created" );
 	return;
     }
 
@@ -101,8 +101,8 @@ sub new {   #### mqtt_DiscoveredItem
     } else {
 	$disc_mode = 'static';
     }
-    if( $disc_topic =~ m|.*/.*| ) {
-	($disc_prefix, $disc_type, $node_id, $device_id) = $disc_topic =~ m|^(.*)/([^/]*)/([^/]+)/([^/]+)/config$|;
+    if( $disc_topic =~ m|/| ) {
+	($disc_prefix, $disc_type, $node_id, $device_id) = $disc_topic =~ m|^(.*)/([^/]+)/([^/]+)/([^/]+)/config$|;
 	if( $disc_prefix ) {
 	    $short_disc_topic = "$disc_type/$node_id/$device_id/config";
 	} else {
@@ -163,17 +163,22 @@ sub new {   #### mqtt_DiscoveredItem
     } else {
 	$disc_cmp = $disc;
     }
-    if( $disc_cmp->{name} ||  (defined $disc_cmp->{name}  &&  $disc->{device}  && $disc->{device}->{name}) ) {
+    if( $disc_cmp->{name}
+    ||  (defined $disc_cmp->{name}  &&  $disc->{device}  && $disc->{device}->{name})
+    ) {
 	if( $disc->{device}  &&  $disc->{device}->{name} ) {
 	    $friendly_name = $disc->{device}->{name};
 	}
 	if( $disc_cmp->{name} ) {
-	    $friendly_name .= " $disc_cmp->{name}";
+	    if( $friendly_name ) {
+		$friendly_name .= ' ';
+	    }
+	    $friendly_name .= $disc_cmp->{name};
 	}
     } elsif( $disc_cmp->{default_entity_id} ) {
 	($friendly_name) = $disc_cmp->{default_entity_id} =~ m/.*\.([\w]+)$/
     } elsif( $node_id ) {
-	$friendly_name = "${node_id}_${device_id}";
+	$friendly_name = "${node_id} ${device_id}";
     } else {
 	$friendly_name = $device_id;
     }
@@ -245,10 +250,11 @@ sub new {   #### mqtt_DiscoveredItem
     # create local MH object name
     if( !$obj_name ) {
 	$obj_name = 'mqttd_';
+	# for some mqtt systems, node_id is pretty narly -- use friendly name instead
+	# ... but friendly_names are necessarily unique
 	if( $friendly_name ) {
 	    $obj_name .= $friendly_name;
 	} else {
-	    # for some mqtt systems, node_id is pretty narly -- use friendly name instead
 	    if( $node_id ) {
 		#  $node_id helps to identify the device
 		$obj_name .= "${node_id}_";
@@ -289,7 +295,7 @@ sub new {   #### mqtt_DiscoveredItem
     $self->{mqtt_friendly_name} = $friendly_name;
 
     $self->debug( 1, "New mqtt_DiscoveredItem( \$$disc_interface->{mqtt_name}, '$obj_name', '$disc_topic', '$disc_msg' )" );
-
+    $self->debug( 2, "    friendly_name:${friendly_name}  node_id:${node_id}  cmp_name:$disc_cmp->{name}" );
     $self->debug( 3, "DiscoveryItem created: \n" . $self->dump( $self, 3 ) );
 
     # We may need flags to deal with XML, JSON or Text
@@ -320,22 +326,19 @@ sub new {  ### mqtt_Discovery
     my ($class, @parmslist ) = @_;
 
     my @positional_parms = qw( interface:objref name discovery_prefix action );
-    my @optional_parms = ();
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing MQTT_DISCOVERY parameters: $parms -- mqtt item not created" );
+    my @optional_parms = qw ( disc_language );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing MQTT_DISCOVERY parameters: $errstr -- mqtt item not created" );
 	return;
     }
 
     my $interface	= $parms->{interface};
     my $name		= $parms->{name};
     my $discovery_prefix= $parms->{discovery_prefix};
-    my $action		= $parms->{action};
+    my $action		= $parms->{action}		||  'both';
+    my $disc_language	= $parms->{disc_language}	||  'ha_raw_entity';
 
-    $discovery_prefix //= $interface->{topic_prefix};
-    if( $discovery_prefix  &&  !$action ) {
-	$action = 'both';
-    }
     if( !$interface ) {
 	&mqtt::error( undef, "mqtt_Discovery must specify interface" );
 	return;
@@ -343,12 +346,21 @@ sub new {  ### mqtt_Discovery
     if( !grep( /^${action}$/, ('publish', 'subscribe', 'both', 'none') ) ) {
 	$interface->error( "Invalid discovery action specified '$action'" );
     }
+    if( !grep( /^${disc_language}$/, ('ha_raw_entity', 'ha_device_info') ) ) {
+	$interface->error( "Invalid discovery language specified '$disc_language'" );
+    }
 
     $interface->debug( 1, "New mqtt_Discovery( $interface->{instance}, '$name', '$discovery_prefix', '$action' )" );
 
+    #######
+    # Setup what to do based on action
+    #######
+
     my $listentopics = [];
     if( $action eq 'publish'  ||  $action eq 'both' ) {
+	$interface->{publish_discovery} = 1;
 	$interface->{discovery_publish_prefix} = $discovery_prefix;
+	$interface->{disc_language} = $disc_language;
     }
     if( $action eq 'subscribe'  ||  $action eq 'both' ) {
 	$listentopics = "$discovery_prefix/#";

--- a/lib/mqtt_items.pm
+++ b/lib/mqtt_items.pm
@@ -141,6 +141,7 @@ Description:
 	- cover
 	- scene
 	- scene_switch            (invented to map to something in HA that has on/off but no state)
+	- button
 
     Note that these (except scene_switch) map to the Home Assistant types directly.
     Also, the type can be enhanced in MH:
@@ -263,7 +264,6 @@ Usage:
 	#     7	   | keepalive_time	    | -none-	| password to use when connecting to MQTT server
 	#	   | grouplist		    | -none-	| MH groups the item belongs to
 	#	   | topic_prefix	    | -none-	| prefix to use on MQTT topics created for LOCALITEMS
-	#	   | use_ha_device_discovery| -none-	| prefix to use on MQTT topics created for LOCALITEMS
 	#
 	# Example .mht:
 	#
@@ -375,9 +375,13 @@ Usage:
 	# MQTT_LOCALITEM,   name,		ref item name,	broker, type,				topic_pattern,		    discoverable    [[Area]:[DeviceName]:]Friendly Name
 	MQTT_LOCALITEM,	    mqtt_shed_light,	shed_light,	mqtt_1, switch,				insteon/shed_light/+,	    1,		    Shed::Shed Light
 	MQTT_LOCALITEM,	    mqtt_outside_temp,	temp,		mqtt_1, sensor:temperature:measurement:C,insteon/outside_temp/+,    1,		    Outside Temperature
+
+	GENERIC,	    my_number
+	MQTT_LOCALITEM,	    mqtt_my_number,	my_number,	mqtt_1, number,				mh/my_number,		    1,		    My Number
+	CODE, $mqtt_my_number->add_discovery_info( {min => 20, max => 40, step => .5, mode => 'box'} );  #noloop
 	#
         #
-	# NOTE:  the positional paramaters to the new mqtt() are in a slightly different order
+	# NOTE:  the positional paramaters to the new mqtt_localitem() are in a slightly different order
 	#        so user code looks like:
 	#     $mqtt_shed_light = new mqtt_LocalItem( <broker>, <name>, <type>, <ref_item_name>, ... )
 	#         OR use keyword parms
@@ -557,7 +561,7 @@ sub new {   ### mqtt_BaseItem
     $self->{topic}		    = $listentopics;
     $self->{disc_type}		    = $type;
 
-#     if( !grep( /^$type$/, ('light', 'switch', 'binary_sensor', 'sensor', 'scene', 'select') ) ) {
+#     if( !grep( /^$type$/, ('light', 'switch', 'binary_sensor', 'sensor', 'scene', 'button', 'select') ) ) {
 # 	$self->error( "UNKNOWN DEVICE TYPE: '$self->{mqtt_name}':$self->{mqtt_type}" );
 # 	return;
 #     }
@@ -610,6 +614,7 @@ sub set_discovery_names {
     my $device_name;
     my $friendly_name;
     my $device_id;
+    my $obj_name;
 
     if( !$full_name ) {
 	$full_name = $mqtt_name;
@@ -631,26 +636,36 @@ sub set_discovery_names {
 	$area_name = "MH MQTT $self->{node_id}";
     }
     $self->{mqtt_friendly_name} = $friendly_name;
-    if( !$device_name ) {
-	$device_name = $friendly_name;
-	if( !$device_name ) {
-	    $device_name = $mqtt_name;
+    $obj_name = $friendly_name || $mqtt_name;
+    $self->{mqtt_disc_language} = $self->{interface}->{disc_language};
+#    if( !$self->{mqtt_disc_language} ) {
+#	if( $self->{mqtt_type} eq 'scene'  ||  $self->{mqtt_type} eq 'button' ) {
+#	    $self->{mqtt_disc_language} = 'ha_raw_entity';
+#	} else {
+#	    $self->{mqtt_disc_language} = $self->{interface}->{disc_language};
+#	}
+#    }
+    if( $self->{mqtt_disc_language} eq 'ha_device_info'  ||  $self->{mqtt_disc_language} eq 'ha_device_type' ) {
+	if( $device_name ) {
+	    # device name specified -- need a unique device_id, can't use component mqtt_name
+	    $device_id = lc( $device_name );
+	    $device_id =~ s/[^\w]+/_/g;
+	} else {
+	    $device_name = $obj_name;
+	    $device_id = $mqtt_name;
+	    $obj_name = '';
 	}
-	$device_id = $mqtt_name;
-	$friendly_name = '';
-    } else {
-	# device name specified -- need a unique device_id, can't use component mqtt_name
-	$device_id = lc( $device_name );
-	$device_id =~ s/[^\w]+/_/g;
     }
     if( !ref $self->{disc} ) {
 	$self->{disc} = {};
     }
 
-    if( $device_name ) {
+    if( $self->{mqtt_disc_language} eq 'ha_device_info'
+    ||  $self->{mqtt_disc_language} eq 'ha_device_type'
+    ) {
 	$self->{disc}->{device} = {};
 	$self->{disc}->{device}->{name} = $device_name;
-	if( $self->{interface}->{use_ha_device_disc} ) {
+	if( $self->{mqtt_disc_language} eq 'ha_device_type' ) {
 	    $self->{disc}->{device}->{identifiers} = $device_id;
 	} else {
 	    $self->{disc}->{device}->{identifiers} = [$device_id];
@@ -661,19 +676,19 @@ sub set_discovery_names {
 	$self->{disc}->{origin}->{sw_version} = "6.0";
 	$self->{disc}->{origin}->{support_url} = 'https://github.com/hollie/misterhouse';
     }
-    if( $self->{interface}->{use_ha_device_disc} ) {
+    if( $self->{mqtt_disc_language} eq 'ha_device_type' ) {
 	$self->{disc}->{components} = {};
 	$self->{disc}->{components}->{$mqtt_name} = {};
 	$self->{disc_info} = $self->{disc}->{components}->{$mqtt_name};
 	$self->{disc_info}->{platform} = $self->{disc_type};
-	$self->{disc_info}->{name} = $friendly_name;
+	$self->{disc_info}->{name} = $obj_name;
 	# $self->{disc_info}->{object_id} = $mqtt_name;
     } else {
 	$self->{disc_info} = $self->{disc};
-	$self->{disc_info}->{name} = $friendly_name;
+	$self->{disc_info}->{name} = $obj_name;
 	# $self->{disc_info}->{object_id} = $mqtt_name;
     }
-    # $self->log( "'$full_name' turned into (fname:'$friendly_name', devname:'$device_name', devid:'$device_id', areaname:'$area_name')" );
+    # $self->log( "'$full_name' turned into (fname:'$friendly_name', devname:'$device_name', devid:'$device_id', areaname:'$area_name'), type:'$self->{mqtt_type}'" );
 }
 
 =item C<set_object_debug( level )>
@@ -905,7 +920,11 @@ sub decode_mqtt_payload {
     if( $topic eq $self->{disc_info}->{command_topic} ) {
 	$value = $payload;
     }
-    $self->debug( 3, "payload '$payload' decoded to: '$value'" );
+    if( !$value && !$brightness ) {
+        $self->debug( 1, "Unknown topic: '$topic' for $$self{mqtt_type}:$$self{mqtt_name} device" );
+        return;
+    }
+    $self->debug( 3, "payload '$payload' decoded to: '$value'  brightness: $brightness" );
 
     # if( $$self{mqtt_type} eq 'binary_sensor'  ||  $$self{mqtt_type} eq 'sensor' ) {
     #	if( $retained ) {
@@ -940,6 +959,7 @@ sub decode_mqtt_payload {
 	}
     } elsif( $$self{mqtt_type} eq 'switch'
     ||       $$self{mqtt_type} eq 'scene'
+    ||       $$self{mqtt_type} eq 'button'
     ||       $$self{mqtt_type} eq 'scene_switch'
     ) {
 	$msg = 'on' if $value eq $value_on;
@@ -973,7 +993,8 @@ sub decode_mqtt_payload {
 	$msg = $value_json;
     }
     if( $msg eq $unset_value ) {
-        $self->error( "Unable to decode mqtt message for $$self{mqtt_name} type:$$self{mqtt_type} message:'$payload'" );
+        $self->error( "Unable to decode mqtt message for $$self{mqtt_name} type:$$self{mqtt_type} topic:$topic message:'$payload'" );
+&main::write_file( 'c:\tmp\json.out', $payload );
 	# $self->error( Dumper( $self ) );
 	$msg = undef;
     }
@@ -1051,6 +1072,7 @@ sub encode_mqtt_payload {
     } elsif( $self->{mqtt_type} eq 'switch'
     ||       $self->{mqtt_type} eq 'binary_sensor'
     ||       $self->{mqtt_type} eq 'scene'
+    ||       $self->{mqtt_type} eq 'button'
     ||       $self->{mqtt_type} eq 'scene_switch'
     ) {
 	$payload = $value;
@@ -1297,7 +1319,7 @@ sub create_discovery_message {
 	my $disc_msg;
     
 	$disc_topic = "$self->{interface}->{discovery_publish_prefix}/";
-	if( $self->{interface}->{use_ha_device_disc} ) {
+	if( $self->{mqtt_disc_language} eq 'ha_device_type' ) {
 	    $disc_topic .= "device/";
 	} else {
 	    $disc_topic .= "$self->{disc_type}/";
@@ -1305,7 +1327,7 @@ sub create_discovery_message {
 	if( $self->{node_id} ) {
 	    $disc_topic .= "$self->{node_id}/";
 	}
-	if( $self->{interface}->{use_ha_device_disc} ) {
+	if( $self->{mqtt_disc_language} eq 'ha_device_type' ) {
 	    $disc_topic .= "$self->{disc}->{device}->{identifiers}/config";
 	} else {
 	    $disc_topic .= "$self->{disc_info}->{unique_id}/config";
@@ -1329,6 +1351,9 @@ sub publish_discovery_message {
     $interface = $self->{interface};
     if( !$self->{interface}->isConnected() ) {
 	$self->error( "Unable to publish $self->{mqtt_name} discovery data -- $interface->{instance} not connected" );
+	return 0;
+    }
+    if( !$self->{interface}->{publish_discovery} ) {
 	return 0;
     }
     if( !$self->{interface}->{discovery_publish_prefix} ) {
@@ -1379,10 +1404,10 @@ sub new {     ### mqtt_LocalItem
     my ($class, @parmslist) = @_;
 
     my @positional_parms = qw( broker:objref name type ref_item_name:objref topic_pattern discoverable friendly_name state_topic command_topic );
-    my @optional_parms = ();
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing MQTT_LOCALITEM parameters: $parms -- mqtt item not created" );
+    my @optional_parms = qw( disc_language );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing MQTT_LOCALITEM parameters: $errstr -- mqtt item not created" );
 	return;
     }
 
@@ -1419,7 +1444,7 @@ sub new {     ### mqtt_LocalItem
         . "' )"
     );
 
-    if( !grep( /^$base_type$/, ('light','switch','binary_sensor', 'sensor', 'scene', 'scene_switch', 'select', 'text', 'number', 'cover' ) ) ) {
+    if( !grep( /^$base_type$/, ('light','switch','binary_sensor', 'sensor', 'scene', 'scene_switch', 'button', 'select', 'text', 'number', 'cover' ) ) ) {
 	$interface->error( "Invalid mqtt type '$type'" );
 	return;
     }
@@ -1482,7 +1507,7 @@ sub new {     ### mqtt_LocalItem
     } elsif( $base_type eq 'scene_switch' ) {
 	# $self->{disc_info}->{optimistic} = 'true';
 	# delete $self->{disc_info}->{state_topic};
-    } elsif( $base_type eq 'scene' ) {
+    } elsif( $base_type eq 'scene'  ||  $base_type eq 'button' ) {
 	$self->{disc_info}->{payload_on} = 'ON';
 	delete $self->{disc_info}->{state_topic};
     } elsif( $base_type eq 'cover' ) {
@@ -1527,6 +1552,7 @@ sub new {     ### mqtt_LocalItem
 	$self->{disc_info}->{unique_id} =~ s/ /_/g;
     }
 
+    $self->debug( 2, "    mqtt_disc_language:$self->{mqtt_disc_language}" );
     # my $d = Data::Dumper->new( [$self] );
     # $d->Maxdepth( 3 );
     # $self->debug( 3, "locale item created: \n" . $d->Dump );
@@ -1611,7 +1637,7 @@ sub set {    ### LocalItem
 	# Note that outgoing state messages are marked to be retained, so that any client can get the latest state info
 	# when it starts up
 	my $retain = 1;
-	if( $self->{disc_type} eq 'scene' ) {
+	if( $self->{disc_type} eq 'scene'  ||  $self->{disc_type} eq 'button' ) {
 	    $retain = 0;
 	}
 	$self->debug( 1, "MH to MQTT LocalItem ${obj_name} set($setval) publishing state message '$payload' to mqtt" );
@@ -1644,8 +1670,11 @@ sub publish_state {
 	}
 	$current_state = $local_item->state;
 	$self_name = $local_item->get_object_name();
-	if( $self->{mqtt_type} eq 'scene'  ||  $self->{mqtt_type} eq 'scene_switch' ) {
-	    $self->debug( 1, "$self_name is a scene -- not publishing current state" );
+	if( $self->{mqtt_type} eq 'scene'
+	||  $self->{mqtt_type} eq 'scene_switch'
+	||  $self->{mqtt_type} eq 'button'
+	) {
+	    $self->debug( 1, "$self_name is a stateless type -- not publishing current state" );
 	    return;
 	}
 	if( $local_item->can('is_responder') && !$local_item->is_responder ) {
@@ -1711,6 +1740,8 @@ sub new {   ### mqtt_BaseRemoteItem
     } elsif( $self->{mqtt_type} eq 'switch' ) {
 	$self->set_states( "off", "on", "offline" );
     } elsif( $self->{mqtt_type} eq 'scene' ) {
+	$self->set_states( "off", "on", "offline" );
+    } elsif( $self->{mqtt_type} eq 'button' ) {
 	$self->set_states( "off", "on", "offline" );
     }
 
@@ -1932,9 +1963,9 @@ sub new {      ### mqtt_RemoteItem
 
     my @positional_parms = qw( broker:objref type topic_pattern discoverable friendly_name state_topic command_topic );
     my @optional_parms = qw( grouplist );
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing MQTT_REMOTEITEM) parameters: $parms -- mqtt item not created" );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing MQTT_REMOTEITEM) parameters: $errstr -- mqtt item not created" );
 	return;
     }
 
@@ -1949,7 +1980,7 @@ sub new {      ### mqtt_RemoteItem
     my ($base_type, $device_class, $state_class, $unit_of_m) = $type =~ m/^([^:]*):?([^:]*):?([^:]*):?([^:]*)$/;
 
     if( !grep( /$base_type/, ('light','switch','sensor','binary_sensor','cover', 'text', 'number', 'select') ) ) {
-	&mqtt::error( undef, "Invalid InstMqttItem type '$type'" );
+	&mqtt::error( undef, "Invalid RemoteItem type '$type'" );
 	return;
     }
 
@@ -2075,9 +2106,9 @@ sub new {      ### mqtt_InstMqttItem
 
     my @positional_parms = qw( broker:objref type topic_pattern discoverable friendly_name );
     my @optional_parms = qw( grouplist );
-    my $parms = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
-    if( !ref $parms ) {
-	&mqtt::error( undef, "error parsing MQTT_INSTMQTTITEM) parameters: $parms -- mqtt item not created" );
+    my ($errstr,$parms) = main::parse_table_parms( \@parmslist, \@positional_parms, \@optional_parms );
+    if( $errstr ) {
+	&mqtt::error( undef, "error parsing MQTT_INSTMQTTITEM) parameters: $errstr -- mqtt item not created" );
 	return;
     }
 
@@ -2089,7 +2120,7 @@ sub new {      ### mqtt_InstMqttItem
 
     my ($base_type, $device_class, $state_class, $unit_of_m) = $type =~ m/^([^:]*):?([^:]*):?([^:]*):?([^:]*)$/;
 
-    if( !grep( /$base_type/, ('light','switch','binary_sensor','sensor','scene', 'cover' ) ) ) {
+    if( !grep( /$base_type/, ('light','switch','binary_sensor','sensor','scene', 'button', 'cover' ) ) ) {
 	$interface->error( "Invalid InstMqttItem type '$type'" );
 	return;
     }
@@ -2098,14 +2129,14 @@ sub new {      ### mqtt_InstMqttItem
     my $mqtt_name;
     my $node_id;
     my $topic_prefix;
-    ($work, $mqtt_name) = $work =~ m|^(.*)/([^/]+)/?\+?$|;
+    ($work, $mqtt_name) = $work =~ m|^(.*)/([^/\+]+)/?\+?$|;
     ($topic_prefix, $node_id) = $work =~ m|^(.*/)([^/]+)$|;
     if( !$node_id ) {
 	$node_id = $work;
 	$topic_prefix = '';
     }
     $topic_prefix .= "$node_id/$mqtt_name";
-    $interface->debug( 3, "topicpattern:'$topicpattern' parsed to node_id:'$node_id' mqtt_name:'$mqtt_name' prefix:'$topic_prefix'" );
+    $interface->debug( 2, "topicpattern:'$topicpattern' parsed to node_id:'$node_id' mqtt_name:'$mqtt_name' prefix:'$topic_prefix'" );
     if( !$mqtt_name ) {
 	$interface->error( "Unrecognized topic pattern '$topicpattern' for device '$friendly_name'" );
     }
@@ -2135,6 +2166,11 @@ sub new {      ### mqtt_InstMqttItem
     }
     if( $base_type eq 'scene' ) {
 	$self->{disc_info}->{command_topic} = "$node_id/modem/scene";
+	$self->{disc_info}->{optimistic} = 'true';
+	$self->{disc_info}->{payload_on} =  "{ \"cmd\" : \"ON\", \"name\" : \"$mqtt_name\" }";
+	$self->{disc_info}->{payload_off} =  "{ \"cmd\" : \"OFF\", \"name\" : \"$mqtt_name\" }";
+    } elsif( $base_type eq 'button' ) {
+	$self->{disc_info}->{command_topic} = "$topic_prefix/fire";
 	$self->{disc_info}->{optimistic} = 'true';
 	$self->{disc_info}->{payload_on} =  "{ \"cmd\" : \"ON\", \"name\" : \"$mqtt_name\" }";
 	$self->{disc_info}->{payload_off} =  "{ \"cmd\" : \"OFF\", \"name\" : \"$mqtt_name\" }";

--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -102,15 +102,33 @@ sub read_table_init_A {
     %scene_build_responders  = ();
 }
 
+sub read_table_A_process_line {
+    my ($record) = @_;
+    my $record_raw;
+
+    $record =~ s/\n\s*([^\\])/\n\1/g;	    # remove white space at beginning of line if line doesn't start with '\'
+    $record =~ s/\n\s*\\/\n/g;		    # remove white space up to '\'
+
+    $record_raw = $record;
+
+    $record =~ s/\s*#[^\n]*\n/\n/g;	    # remove comments at end of lines except last line
+    $record =~ s/\n//g;			    # remove remaining newlines
+    $record =~ s/\s*#.*$//;		    # remove comment on last line
+
+    return ($record, $record_raw);
+}
 
 sub read_table_A {
     my ($record) = @_;
-    my $record_raw = $record;
+    my $record_raw;
 
-    if ( $record =~ /^#/ or $record =~ /^\s*$/ ) {
+    ($record,$record_raw) = read_table_A_process_line( $record );
+
+    if ( $record =~ /^\s*$/ ) {
         return;
     }
-    $record =~ s/\s*#.*$//;
+
+    &parse_table_debug( "Read_table_A processing record '$record'" );
 
     my (
         $code,      $address,    $name,      $object,
@@ -594,8 +612,18 @@ sub read_table_A {
     elsif ( $type eq "CODE" ) {
 	#<,CODE,Code>#
         # This is for simple one line additions such as setting an attribute or adding an image.
-        ($object) = "$record_raw" =~ /CODE,\s+(.*)/;
+	$object = $record_raw;
+        $object =~ s/^CODE\s*,//;
         $code   = "$object\n";
+        $object = '';
+    }
+    elsif ( $type eq "CODE_NOW" ) {
+	#<CODE_NOW,Code>#
+        # This is for running code during the .mht file processing -- can use for debugging file processing
+	$object = $record_raw;
+        $object =~ s/^CODE_NOW\s*,//;
+	eval( $object );
+        $code   = '';
         $object = '';
     }
     elsif ( $type eq "LIGHT" ) {
@@ -2042,14 +2070,22 @@ sub read_table_A {
 	$object = "mqtt_Discovery( '$broker', '$name', '$discovery_topic', $other )";
     }
     elsif( $type eq "MQTT_DISCOVEREDITEM" ) {
-	my ($disc_name, $disc_topic, $disc_msg );
-	($name, $disc_name, $disc_topic, $disc_msg ) = $record =~ /MQTT_DISCOVEREDITEM\s*,\s*([^,]+),\s*([^,]+),\s*([^,]+)\,\s*(.*)$/;
-	$name =~ s/\s*$//;
-	$disc_name =~ s/\s*$//;
-	$disc_topic =~ s/\s*$//;
-	$disc_msg =~ s/\s*$//;
-	$disc_msg =~ s/\'/\\'/g;
-	$object = "mqtt_DiscoveredItem( \$${disc_name}, '$name', '$disc_topic', '$disc_msg' );\n";
+	&parse_table_debug( "MQTT_DISCOVEREDITEM table entry '$record_raw'" );
+	# NOTE: $record_raw can have newlines -- be careful with $ in pattern matches
+	my $str = $record_raw;
+	$str =~ s/^MQTT_DISCOVEREDITEM\s*,//;
+	my ($errstr,$parms) = &split_table_parms( $str );
+	if( $errstr ) {
+	    print "ERROR: parsing MQTT_DISCOVEREDITEM: $errstr\n";
+	} else {
+	    $grouplist = &get_table_parm( $parms, 'grouplist' );
+	    $name = &get_table_parm( $parms, 'name', 1 );
+	    # NOTE: we pull these parms out so we can change the order for the new() function
+	    my ($disc_name, @other) = @{$parms};
+	    $other = join ', ', ( map { "'$_'" } @other );              # Quote data
+	    $object = "mqtt_DiscoveredItem( \$$disc_name, '$name', $other );";
+	    &parse_table_debug( "MQTT_DISCOVEREDITEM object: $object" );
+	}
     }
     #-------------- End MQTT Objects ----------------
     #-------------- Home Assistant Objects -----------------

--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -617,7 +617,7 @@ sub read_table_A {
 	#<,CODE,Code>#
         # This is for simple one line additions such as setting an attribute or adding an image.
 	$object = $record_raw;
-        $object =~ s/^CODE\s*,//;
+        $object =~ s/^CODE\s*,\s*//;
         $code   = "$object\n";
         $object = '';
     }
@@ -625,7 +625,7 @@ sub read_table_A {
 	#<CODE_NOW,Code>#
         # This is for running code during the .mht file processing -- can use for debugging file processing
 	$object = $record_raw;
-        $object =~ s/^CODE_NOW\s*,//;
+        $object =~ s/^CODE_NOW\s*,\s*//;
 	eval( $object );
         $code   = '';
         $object = '';

--- a/lib/read_table_A.pl
+++ b/lib/read_table_A.pl
@@ -103,32 +103,36 @@ sub read_table_init_A {
 }
 
 sub read_table_A_process_line {
-    my ($record) = @_;
-    my $record_raw;
+    my ($record_raw) = @_;
+    my $record;
 
-    $record =~ s/\n\s*([^\\])/\n\1/g;	    # remove white space at beginning of line if line doesn't start with '\'
-    $record =~ s/\n\s*\\/\n/g;		    # remove white space up to '\'
+    # Note -- perl '\s' matches newlines so need to be careful in its use here until newlines
+    # are eliminated from the string
 
-    $record_raw = $record;
+    $record_raw =~ s/\n[\ \t]+([^\\])/\n\1/g;	# remove white space at beginning of line if line doesn't start with '\'
+    $record_raw =~ s/\n[\ \t]+\\/\n/g;		# remove white space up to '\'
 
-    $record =~ s/\s*#[^\n]*\n/\n/g;	    # remove comments at end of lines except last line
-    $record =~ s/\n//g;			    # remove remaining newlines
-    $record =~ s/\s*#.*$//;		    # remove comment on last line
+    $record = $record_raw;
+
+    $record =~ s/[\ \t]*#[^\n]*\n//g;		# remove comments at end of lines except last line
+    $record =~ s/\n//g;				# remove remaining newlines
+    $record =~ s/\s*#.*$//;			# remove comment on last line
 
     return ($record, $record_raw);
 }
 
 sub read_table_A {
-    my ($record) = @_;
+    my ($line) = @_;
+    my $record;
     my $record_raw;
 
-    ($record,$record_raw) = read_table_A_process_line( $record );
+    ($record,$record_raw) = read_table_A_process_line( $line );
 
     if ( $record =~ /^\s*$/ ) {
         return;
     }
 
-    &parse_table_debug( "Read_table_A processing record '$record'" );
+    &parse_table_debug( 1, "Read_table_A processing record '$record'" );
 
     my (
         $code,      $address,    $name,      $object,
@@ -2070,7 +2074,7 @@ sub read_table_A {
 	$object = "mqtt_Discovery( '$broker', '$name', '$discovery_topic', $other )";
     }
     elsif( $type eq "MQTT_DISCOVEREDITEM" ) {
-	&parse_table_debug( "MQTT_DISCOVEREDITEM table entry '$record_raw'" );
+	&parse_table_debug( 2, "MQTT_DISCOVEREDITEM table entry '$record_raw'" );
 	# NOTE: $record_raw can have newlines -- be careful with $ in pattern matches
 	my $str = $record_raw;
 	$str =~ s/^MQTT_DISCOVEREDITEM\s*,//;
@@ -2084,7 +2088,7 @@ sub read_table_A {
 	    my ($disc_name, @other) = @{$parms};
 	    $other = join ', ', ( map { "'$_'" } @other );              # Quote data
 	    $object = "mqtt_DiscoveredItem( \$$disc_name, '$name', $other );";
-	    &parse_table_debug( "MQTT_DISCOVEREDITEM object: $object" );
+	    &parse_table_debug( 2, "MQTT_DISCOVEREDITEM object: $object" );
 	}
     }
     #-------------- End MQTT Objects ----------------


### PR DESCRIPTION
bin\mh:
    - removed extra eval line in mh -- left over from previous iteration of Brian's changes
handy_utilities.pl:
    - moved comment processing from line continuation code into read_table_A so that comments can be passed thru
    - added split_table_parms to split the raw record into the list of items -- handles JSON objects
    - cleaned up parse_table_parms (ha_item.pm as well)
read_table_A.pl:
    - fixed problem where comments were being stripped off CODE items -- particularly #noloop
    - added CODE_NOW item type to allow code to be executed right during processing of .mht files
        - useful for turning on debugging
mqtt.pm:
    - added function to subscribe/resubscribe to the mqtt topics
    -     also means that after deleting all retained topics, resubscribe will get the new list of retained topics
    - added add_ignore_topic to specify a pattern for mqtt topics to be ignored
    - cleaned up debugging
    - pretty print the output for write_discovered_items 
mqtt_items.pm:
    - added support for button type
mqtt_discovery.pm:
    - added ability to specify discovery language on the discovery object -- supported languages:
        - ha_raw_entity -- only entity information is published
	- ha_device_info -- entity information includes device info and origin info
    - improved naming of misterhouse item in write_discovered_items
    - enhanced splitting of MQTT_DISCOVEREDITEM table entries to handle named parms and better scan JSON
    - added grouplist parm for MQTT_DISCOVERDITEM
    - pretty print the output for write_discovered_items 
